### PR TITLE
Fix interpreter eager null check for this parameter on s390x

### DIFF
--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -10004,22 +10004,22 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
         }
         // AV -> NullRef translation is NYI for the interpreter,
         // so we should manually check and throw the correct exception.
-        if (args[curArgSlot] == NULL)
-        {
+        //if (args[curArgSlot] == NULL)
+        //{
             // If we're calling a constructor, we bypass this check since the runtime
             // should have thrown OOM if it was unable to allocate an instance.
-            if (m_callThisArg == NULL)
-            {
-                _ASSERTE(!methToCall->IsStatic());
-                ThrowNullPointerException();
-            }
+          //  if (m_callThisArg == NULL)
+           // {
+           //     _ASSERTE(!methToCall->IsStatic());
+           //     ThrowNullPointerException();
+           // }
             // ...except in the case of strings, which are both
             // allocated and initialized by their special constructor.
-            else
-            {
-                _ASSERTE(methToCall->IsCtor() && methToCall->GetMethodTable()->IsString());
-            }
-        }
+            //else
+            //{
+            //    _ASSERTE(methToCall->IsCtor() && methToCall->GetMethodTable()->IsString());
+            //}
+        //}
         curArgSlot++;
     }
 


### PR DESCRIPTION
## Problem

The interpreter was performing an unconditional null check on the `this` parameter at method entry (line 10007-10014 in `interpreter.cpp`). This caused `NullReferenceException` to be thrown even when the method's execution path never dereferenced `this`.

## Root Cause

The check at method entry was too eager:

```
if (args[curArgSlot] == NULL) // 'this' is null
{
    if (m_callThisArg == NULL)
    {
        ThrowNullPointerException(); //  Throws immediately!
    }
}
```
This violated .NET semantics: null checks should be **lazy** (validated only at field access via `ldfld`), not **eager** (validated at method entry).


## Fix

Removed the eager null check. The interpreter already performs null validation at `CEE_LDFLD` instructions (the correct location). This aligns s390x interpreter behavior with JIT behavior on other architectures (x64, ARM64).