### PR TITLE
Handle zero-size InitBlk/CpBlk + fix big-endian test issues.

### DIFF
--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -8815,12 +8815,19 @@ void Interpreter::InitBlk()
     if (sizeCIT != CORINFO_TYPE_INT && !isLong)
         VerificationError("Size of InitBlk must be int");
 #endif // _DEBUG
+    size_t size = (size_t) ((isLong) ? OpStackGet<UINT64>(sizeInd) : OpStackGet<UINT32>(sizeInd));
+    if (size==0)
+    {
+        m_curStackHt = addrInd;
+        m_ILCodePtr += 2;
+        BarrierIfVolatile();
+        return;
+    }
 
     void* addr = OpStackGet<void*>(addrInd);
     ThrowOnInvalidPointer(addr);
     GCX_FORBID(); // addr is a potentially vulnerable byref.
     INT8 val = OpStackGet<INT8>(valInd);
-    size_t size = (size_t) ((isLong) ? OpStackGet<UINT64>(sizeInd) : OpStackGet<UINT32>(sizeInd));
     memset(addr, val, size);
 
     m_curStackHt = addrInd;
@@ -8871,13 +8878,19 @@ void Interpreter::CpBlk()
         VerificationError("Size of CpBlk must be int");
 #endif // _DEBUG
 
+    size_t size = (size_t)((isLong) ? OpStackGet<UINT64>(sizeInd) : OpStackGet<UINT32>(sizeInd));
+    if (size==0){
+            m_curStackHt = destInd;
+            m_ILCodePtr += 2;
+            BarrierIfVolatile();
+            return;
+    }
 
     void* destAddr = OpStackGet<void*>(destInd);
     void* srcAddr = OpStackGet<void*>(srcInd);
     ThrowOnInvalidPointer(destAddr);
     ThrowOnInvalidPointer(srcAddr);
     GCX_FORBID(); // destAddr & srcAddr are potentially vulnerable byrefs.
-    size_t size = (size_t)((isLong) ? OpStackGet<UINT64>(sizeInd) : OpStackGet<UINT32>(sizeInd));
     memcpyNoGCRefs(destAddr, srcAddr, size);
 
     m_curStackHt = destInd;

--- a/src/tests/JIT/Directed/perffix/primitivevt/identity3.il
+++ b/src/tests/JIT/Directed/perffix/primitivevt/identity3.il
@@ -425,6 +425,7 @@
       IL_04b3:  call       native int [nativeinthelper]PrimitiveVT.VT1B::op_Subtraction(valuetype [nativeinthelper]PrimitiveVT.VT1B,
                                                                           valuetype [nativeinthelper]PrimitiveVT.VT1B)
       IL_04b8:  ldc.i4.8
+      IL_04b4:  conv.i4
       IL_04b9:  beq.s      IL_04e3
 
       IL_04bb:  ldstr      "FAILED, y-Int32.MinValue!=8"

--- a/src/tests/JIT/Methodical/xxblk/dynblk.il
+++ b/src/tests/JIT/Methodical/xxblk/dynblk.il
@@ -68,7 +68,7 @@
 
               ldloca.s   S
               ldfld      uint64 Test_dynblk_il.S8::val
-              ldc.i8     0x5555333333
+              ldc.i8     0x3333335555000000
               ceq
               brtrue.s  L1
 

--- a/src/tests/JIT/opt/Structs/structcopies.cs
+++ b/src/tests/JIT/opt/Structs/structcopies.cs
@@ -66,7 +66,7 @@ namespace TestStructFields
             [FieldOffset(0)] public byte b0;
             [FieldOffset(3)] public byte b1;
         }
-
+        static bool BE => !BitConverter.IsLittleEndian;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         static int TestS4_Simple()
@@ -253,11 +253,11 @@ namespace TestStructFields
 
             s2.b0 = false;
             s1 = Unsafe.As<S4Corrupted1, S4>(ref s2);
-            if (s1.i != 0)
+            if (s1.i != (BE ? 2 : 0))
             {
                 return 101;
             }
-            if (s2.i != 0)
+            if (s2.i != (BE ? 2 : 0))
             {
                 return 101;
             }
@@ -288,11 +288,11 @@ namespace TestStructFields
 
             s2.b0 = false;
             s1 = Unsafe.As<S4Corrupted2, S4>(ref s2);
-            if (s1.i != 0)
+	    if (s1.i != (BE ? 2 : 0))
             {
                 return 101;
             }
-            if (s2.i != 0)
+	    if (s2.i != (BE ? 2 : 0))
             {
                 return 101;
             }
@@ -312,7 +312,7 @@ namespace TestStructFields
             }
             s1 = Unsafe.As<S4Corrupted3, S4>(ref s2);
             s2.b0 = 2;
-            if (s1.i != 1)
+            if (s1.i != (BE ? 16777216 : 1))
             {
                 return 101;
             }
@@ -323,7 +323,7 @@ namespace TestStructFields
 
             s2.b1 = 1;
             s1 = Unsafe.As<S4Corrupted3, S4>(ref s2);
-            if (s1.i != 16777218)
+            if (s1.i != (BE ? 33554433 : 16777218))
             {
                 return 101;
             }
@@ -791,7 +791,7 @@ namespace TestStructFields
             {
                 return 101;
             }
-            if (s1.i2 != 0x01000004)
+            if (s1.i2 != (BE ? 1 : 0x01000004))
             {
                 return 101;
             }
@@ -800,7 +800,7 @@ namespace TestStructFields
             {
                 return 101;
             }
-            if (s2.i2 != 0x01000104)
+            if (s2.i2 != (BE ? 65537 : 0x01000104))
             {
                 return 101;
             }
@@ -830,7 +830,7 @@ namespace TestStructFields
             {
                 return 101;
             }
-            if (s1.i2 != 0x02000000)
+            if (s1.i2 != (BE ? 2 : 0x02000000))
             {
                 return 101;
             }
@@ -849,7 +849,7 @@ namespace TestStructFields
             {
                 return 101;
             }
-            if (s1.i2 != 0x05000000)
+            if (s1.i2 != (BE ? 5 : 0x05000000))
             {
                 return 101;
             }


### PR DESCRIPTION
-Add early return in InitBlk and CpBlk when block size == 0 to avoid unnecessary pointer validation and memory operations. -Adjust tests to account for big endian behavior.