### PR TITLE
Fix multiple interpreter crashes: SEH stale pointer, dynamic string resolution, null TypeHandle, and missing null-this check: JIT.JIT_r/r0

### DIFF
--- a/src/coreclr/pal/src/exception/seh-unwind.cpp
+++ b/src/coreclr/pal/src/exception/seh-unwind.cpp
@@ -660,7 +660,8 @@ BOOL PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextP
     // If that's the case, extract its local variable containing a pointer to the windows style context of the hardware
     // exception and return that. This skips the hardware signal handler trampoline that the libunwind
     // cannot cross on some systems. On macOS, it skips a similar trampoline we create in HijackFaultingThread.
-    if ((void*)curPc == g_SEHProcessExceptionReturnAddress)
+    if (g_SEHProcessExceptionReturnAddress != NULL &&
+        (void*)curPc == g_SEHProcessExceptionReturnAddress)
     {
         CONTEXT* exceptionContext = *(CONTEXT**)(CONTEXTGetFP(context) + g_hardware_exception_context_locvar_offset);
         memcpy_s(context, sizeof(CONTEXT), exceptionContext, sizeof(CONTEXT));
@@ -672,7 +673,8 @@ BOOL PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextP
     // If that's the case, extract its local variable containing a pointer to the windows style context of the activation
     // injection location and return that. This skips the signal handler trampoline that the libunwind
     // cannot cross on some systems.
-    if ((void*)curPc == g_InvokeActivationHandlerReturnAddress)
+    if (g_InvokeActivationHandlerReturnAddress != NULL &&
+        (void*)curPc == g_InvokeActivationHandlerReturnAddress)
     {
         CONTEXT* activationContext = (CONTEXT*)(CONTEXTGetFP(context) + g_inject_activation_context_locvar_offset);
         memcpy_s(context, sizeof(CONTEXT), activationContext, sizeof(CONTEXT));

--- a/src/coreclr/pal/src/exception/seh.cpp
+++ b/src/coreclr/pal/src/exception/seh.cpp
@@ -268,6 +268,7 @@ SEHProcessException(PAL_SEHException* exception)
                 if (g_hardwareExceptionHandler(exception))
                 {
                     // The exception happened in managed code and the execution should continue.
+                    g_SEHProcessExceptionReturnAddress = NULL;  // Reset to prevent stale value false matches
                     return TRUE;
                 }
 
@@ -284,6 +285,7 @@ SEHProcessException(PAL_SEHException* exception)
     }
 
     // Unhandled hardware exception pointers->ExceptionRecord->ExceptionCode at pointers->ExceptionRecord->ExceptionAddress
+    g_SEHProcessExceptionReturnAddress = NULL;  // Reset to prevent stale value false matches
     return FALSE;
 }
 

--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -6645,6 +6645,10 @@ void Interpreter::RefanyType()
 OBJECTREF Interpreter::TypeHandleToTypeRef(TypeHandle* pth)
 {
     OBJECTREF typePtr = NULL;
+    if (pth->IsNull())
+    {
+        return NULL;
+    }
     if (!pth->IsTypeDesc())
     {
         // Most common... and fastest case
@@ -10246,6 +10250,8 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
             {
                 thisArgHnd = OpStackGetAddr<Object*>(argsBase);
             }
+            _ASSERTE(thisArgHnd != NULL);
+            ThrowOnInvalidPointer(*thisArgHnd);
         }
 
         Frame* topFrameBefore = thr->GetFrame();

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -1399,6 +1399,13 @@ OBJECTHANDLE ConstructStringLiteral(CORINFO_MODULE_HANDLE scopeHnd, mdToken meta
 
     _ASSERTE(TypeFromToken(metaTok) == mdtString);
 
+    // For dynamic scopes (LCG methods, IL stubs), use the resolver's own
+    // ConstructStringLiteral method which has access to the string table.
+    if (IsDynamicScope(scopeHnd))
+    {
+        return GetDynamicResolver(scopeHnd)->ConstructStringLiteral(metaTok);
+    }
+
     Module* module = GetModule(scopeHnd);
     return module->ResolveStringRef(metaTok, ppPinnedString);
 }


### PR DESCRIPTION
#### 1. SIGSEGV during stack unwinding (seh-unwind.cpp, seh.cpp)

`g_SEHProcessExceptionReturnAddress` held a stale value from a previous exception, causing `PAL_VirtualUnwind` to falsely match the current program counter and read an invalid context. Fixed by adding null checks before comparing and resetting the variable to NULL after exception handling.

#### 2. BadImageFormatException in dynamic methods (jithelpers.cpp)

The interpreter hit "No string associated with token" when executing `ldstr` inside dynamic methods like `CallSite.Target`. `ConstructStringLiteral` always used `module->ResolveStringRef()`, but dynamic scopes store strings in the `DynamicResolver`, not in module metadata. Fixed by adding an `IsDynamicScope` check to use the resolver's own string lookup, matching the JIT's existing behavior.

#### 3. SIGSEGV on null TypeHandle (interpreter.cpp)

`__reftype(default)` produces a null TypeHandle. `TypeHandleToTypeRef` tried to dereference a null MethodTable pointer. Initially fixed by throwing NRE, but that broke cases where null is passed as an argument (e.g. `typeof(int).IsAssignableFrom(null)` expects `false`, not an exception). Changed to returning NULL so managed code can decide — argument cases return false, receiver cases throw NRE at the call site.

#### 4. Missing null-this check for non-virtual methods (interpreter.cpp)

Returning NULL exposed that the interpreter's null-this check only ran inside the vtable dispatch block, which executes only for virtual methods. Non-virtual methods like `IsAssignableTo` skipped it, so calling them on null silently ran the method body instead of throwing NRE. Fixed by adding an unconditional `ThrowOnInvalidPointer` check for all instance method calls, matching the CLR spec.