### PR TITLE
Fix interpreter big-endian issues: OpStackSet zeroing, float-double boxing, signed comparison

### DIFF
--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -7140,7 +7140,7 @@ INT32 Interpreter::CompareOpRes(unsigned op1idx)
                  (cit2 == CORINFO_TYPE_VALUECLASS
                   && CorInfoTypeStackNormalize(GetTypeForPrimitiveValueClass(t2.ToClassHandle())) == CORINFO_TYPE_NATIVEINT))
         {
-            NativeInt val1 = OpStackGet<NativeInt>(op1idx);
+            NativeInt val1 = static_cast<NativeInt>(OpStackGet<INT32>(op1idx));
             NativeInt val2 = OpStackGet<NativeInt>(op2idx);
             if (op == CO_EQ)
             {
@@ -8926,6 +8926,21 @@ void Interpreter::Box()
         {
             // Operand stack entry *is* the data.
             size_t classSize = getClassSize(boxTypeClsHnd);
+            CorInfoType stackCit = valIt.ToCorInfoType();
+	    CorInfoType boxCit = GetTypeForPrimitiveValueClass(boxTypeClsHnd);
+
+            // Float and double have incompatible IEEE 754 encodings -- a raw
+            // memcpy of the wrong width produces garbage.  Perform the same
+            // implicit conversion the JIT does (importer.cpp:3635-3638).
+            if (stackCit == CORINFO_TYPE_FLOAT && boxCit == CORINFO_TYPE_DOUBLE)
+            {
+                OpStackSet<double>(ind, static_cast<double>(OpStackGet<float>(ind)));
+            }
+            else if (stackCit == CORINFO_TYPE_DOUBLE && boxCit == CORINFO_TYPE_FLOAT)
+            {
+                OpStackSet<float>(ind, static_cast<float>(OpStackGet<double>(ind)));
+            }
+
             valPtr = OpStackGetAddr(ind, classSize);
         }
 

--- a/src/coreclr/vm/interpreter.h
+++ b/src/coreclr/vm/interpreter.h
@@ -1244,6 +1244,27 @@ private:
     template<typename T>
     __forceinline void OpStackSet(unsigned ind, T val)
     {
+#ifdef BIGENDIAN
+        // On big-endian, ArgSlotEndiannessFixup places sub-8-byte values at an offset
+        // within the 8-byte slot (e.g. 4-byte values go to bytes 4-7). The leading bytes
+        // are never written, so a later 8-byte read (e.g. OpStackGet<NativeInt> on a slot
+        // that was written as INT32) picks up stale data.  Pre-fill the entire slot with
+        // the correct extension: sign-extend for signed integers so that negative values
+        // survive a wider read, zero-extend for everything else.
+        if constexpr(sizeof(T) < sizeof(INT64))
+        {
+            INT64 extended;
+            if constexpr(std::is_integral<T>::value && std::is_signed<T>::value)
+                extended = static_cast<INT64>(val);
+            else
+                extended = 0;
+#if COMBINE_OPSTACK_VAL_TYPE
+            m_operandStackX[ind].m_val = extended;
+#else
+            m_operandStack[ind] = extended;
+#endif
+        }
+#endif
         *OpStackGetAddr<T>(ind) = val;
     }
 


### PR DESCRIPTION
Fix interpreter big-endian issues: OpStackSet zeroing, float-double boxing, signed comparison

1. OpStackSet (interpreter.h): Pre-fill 8-byte slots on big-endian before
   writing sub-8-byte values, sign-extend signed integers, zero-extend
   everything else -- so later wider reads don't pick up stale data.

2. Box (interpreter.cpp): Promote float<->double in-place before boxing
   when the operand stack type doesn't match the box target type, mirroring
   the JIT's cast insertion in importer.cpp.

3. CompareOpRes (interpreter.cpp): Sign-extend INT32 to NativeInt when
   comparing against a NativeInt operand, fixing misinterpretation of
   negative values in sort/comparison tests.

