### PR TITLE
Fix incomplete eager null check guard for non-virtual calls in interpreter

### DIFF
--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -10040,22 +10040,22 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
         }
         // AV -> NullRef translation is NYI for the interpreter,
         // so we should manually check and throw the correct exception.
-        //if (args[curArgSlot] == NULL)
-        //{
+        if (virtualCall && args[curArgSlot] == NULL)
+        {
             // If we're calling a constructor, we bypass this check since the runtime
             // should have thrown OOM if it was unable to allocate an instance.
-          //  if (m_callThisArg == NULL)
-           // {
-           //     _ASSERTE(!methToCall->IsStatic());
-           //     ThrowNullPointerException();
-           // }
+            if (m_callThisArg == NULL)
+            {
+                _ASSERTE(!methToCall->IsStatic());
+                ThrowNullPointerException();
+            }
             // ...except in the case of strings, which are both
             // allocated and initialized by their special constructor.
-            //else
-            //{
-            //    _ASSERTE(methToCall->IsCtor() && methToCall->GetMethodTable()->IsString());
-            //}
-        //}
+            else
+            {
+                _ASSERTE(methToCall->IsCtor() && methToCall->GetMethodTable()->IsString());
+            }
+        }
         curArgSlot++;
     }
 
@@ -10279,7 +10279,8 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
                 thisArgHnd = OpStackGetAddr<Object*>(argsBase);
             }
             _ASSERTE(thisArgHnd != NULL);
-            ThrowOnInvalidPointer(*thisArgHnd);
+            if (virtualCall)
+	    	ThrowOnInvalidPointer(*thisArgHnd);
         }
 
         Frame* topFrameBefore = thr->GetFrame();


### PR DESCRIPTION


PR #14 (https://github.com/giritrivedi/runtime/pull/14) commented out the first eager null check on the 'this' parameter in DoCallWork, but missed a second check at ThrowOnInvalidPointer(*thisArgHnd) which also fires before method dispatch

Both checks now guard on virtualCall: non-virtual 'call' instructions are
allowed to pass null as 'this' (the method only faults if it actually
dereferences 'this' via ldfld/stfld), while virtual 'callvirt' instructions
correctly throw NullReferenceException immediately since vtable lookup
requires a valid object.

Fixes: thisnull_r (Methodical_r2), thisnull_d (Methodical_d2)