### PR TITLE
Implemetation of srk instruction 

### DIFF
--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -4745,6 +4745,9 @@ instruction CodeGen::genGetInsForOper(genTreeOps oper, var_types type)
         case GT_ADD:
             ins = INS_ark;
             break;
+        case GT_SUB:
+            ins = INS_srk;
+            break;
 #if 0
         case GT_AND:
             ins = INS_and;
@@ -4778,9 +4781,6 @@ instruction CodeGen::genGetInsForOper(genTreeOps oper, var_types type)
         case GT_RSZ:
             ins = INS_lsr;
             break;
-        case GT_SUB:
-            ins = INS_sub;
-	    break;
         case GT_XOR:
             ins = INS_eor;
             break;

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -5487,9 +5487,7 @@ void emitter::emitIns_R_R_R(instruction     ins,
             break;
 #endif
         case INS_ark:
-#if 0
-        case INS_sub:
-#endif
+        case INS_srk:
             if (isVectorRegister(reg1))
             {
                 // ASIMD instruction
@@ -6350,9 +6348,7 @@ void emitter::emitIns_R_R_R_I(instruction     ins,
             break;
 #endif
         case INS_ark:
-#if 0
-        case INS_sub:
-#endif
+        case INS_srk:
             setFlags = false;
             isAddSub = true;
             break;
@@ -10563,9 +10559,15 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             op = emitInsCode(ins, fmt);
        	    S390_RRF_a(dst, op, id->idReg3(), id->idReg1(), id->idReg2());
             break;
-        case INS_nop:
+
+    case INS_nop:
             op = emitInsCode(ins, fmt);
-	    S390_RR(dst, op, 0, 0); 
+            S390_RR(dst, op, 0, 0);
+            break;
+
+    case INS_srk:
+            op = emitInsCode(ins, fmt);
+            S390_RRF_a(dst, op, id->idReg3(), id->idReg1(), id->idReg2());
             break;
 	   
 	default:

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -10496,82 +10496,84 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         emitAttr elemsize;
         emitAttr datasize;
 	
-	case INS_br: 
+        case INS_br:
             assert(ins == INS_br);
             op = emitInsCode(ins, fmt);
-	    S390_RR(dst, op, id->idReg1(), 0); 
+            S390_RR(dst, op, id->idReg1(), 0);
             break;
-	case INS_ret: 
+
+        case INS_ret:
             assert(ins == INS_ret);
             op = emitInsCode(ins, fmt);
-	    S390_RR(dst, op, 0xf, id->idReg1());
+            S390_RR(dst, op, 0xf, id->idReg1());
             break;
-	case INS_st:
+
+        case INS_st:
             imm = emitGetInsSC(id); //get instruction's constant value
             assert((imm >= 0) && (imm <= 2047)); // 11 bit imm unsigned value
             op = emitInsCode(ins, fmt);
-	    S390_RX_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            S390_RX_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
             break;
-	    
-	case INS_stg:
-	    op = emitInsCode(ins, fmt);
-	    imm = emitGetInsSC(id);
-	    S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
-	    break;
-	    
-	case INS_stmg:
-	    op = emitInsCode(ins, fmt);
-	    imm = emitGetInsSC(id);
-	    S390_RSY_a(dst, op, id->idReg1(), id->idReg2(), id->idReg3(), imm);
-	    break;
 
-	case INS_lmg:
-	    op = emitInsCode(ins, fmt);
-	    imm = emitGetInsSC(id);
-	    S390_RSY_a(dst, op, id->idReg1(), id->idReg2(), id->idReg3(), imm);
-	    break;
-
-	case INS_lay:
+        case INS_stg:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-	    S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            break;
+	    
+        case INS_stmg:
+            op = emitInsCode(ins, fmt);
+            imm = emitGetInsSC(id);
+            S390_RSY_a(dst, op, id->idReg1(), id->idReg2(), id->idReg3(), imm);
             break;
 
-	case INS_l:    
+        case INS_lmg:
+            op = emitInsCode(ins, fmt);
+            imm = emitGetInsSC(id);
+            S390_RSY_a(dst, op, id->idReg1(), id->idReg2(), id->idReg3(), imm);
+            break;
+
+        case INS_lay:
+            op = emitInsCode(ins, fmt);
+            imm = emitGetInsSC(id);
+            S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            break;
+
+        case INS_l:
             imm = emitGetInsSC(id); //get instruction's constant value
             assert((imm >= 0) && (imm <= 2047)); // unsigned 11 bits
             op = emitInsCode(ins, fmt);
-	    S390_RX_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
-	    break;
+            S390_RX_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            break;
 
-	case INS_lgr:
-	    op = emitInsCode(ins, fmt);
-	    S390_RRE(dst, op, id->idReg1(), id->idReg2());
-	    break;
-       
-	case INS_lgfi: 
+        case INS_lgr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, id->idReg1(), id->idReg2());
+            break;
+
+        case INS_lgfi:
             imm = emitGetInsSC(id);
             op = emitInsCode(ins, fmt);
-	    S390_RIL_a(dst, op, id->idReg1(), imm);
-	    break;
+            S390_RIL_a(dst, op, id->idReg1(), imm);
+            break;
 
         case INS_ark: 
             op = emitInsCode(ins, fmt);
        	    S390_RRF_a(dst, op, id->idReg3(), id->idReg1(), id->idReg2());
             break;
 
-    case INS_nop:
+        case INS_nop:
             op = emitInsCode(ins, fmt);
             S390_RR(dst, op, 0, 0);
             break;
 
-    case INS_srk:
+        case INS_srk:
             op = emitInsCode(ins, fmt);
             S390_RRF_a(dst, op, id->idReg3(), id->idReg1(), id->idReg2());
             break;
 	   
-	default:
-	    _ASSERTE(!"NYI");
+        default:
+            _ASSERTE(!"NYI");
             break;
     }
 

--- a/src/coreclr/jit/instrss390x.h
+++ b/src/coreclr/jit/instrss390x.h
@@ -58,7 +58,7 @@ INST(lay,		"lay",			0,		0xe371)
 
 //// R_R_R
 INST(ark,		"ark",			0,		0xb9f8)
-
+INST(srk,       "srk",          0,      0xb9f9)
 //// R_R_R_I
 INST(stmg,		"stmg",			0,		0xeb24)
 INST(lmg,		"lmg",			0,		0xeb04)

--- a/src/coreclr/jit/lowers390x.cpp
+++ b/src/coreclr/jit/lowers390x.cpp
@@ -561,7 +561,6 @@ GenTree* Lowering::LowerMul(GenTreeOp* mul)
 //
 GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
 {
-    //_ASSERTE(!"NYI");
     if (comp->opts.OptimizationEnabled())
     {
         if (binOp->OperIs(GT_AND))
@@ -587,7 +586,8 @@ GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
                 BlockRange().Remove(notNode);
             }
         }
-
+#if 0
+#ifdef TARGET_S390X
         if (binOp->OperIs(GT_AND, GT_OR))
         {
             GenTree* next;
@@ -608,6 +608,8 @@ GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
             }
         }
 */
+#endif
+#endif
     }
 
     ContainCheckBinary(binOp);


### PR DESCRIPTION
Sample Program:

srk instruction currently implemented.

```
class HelloWorld
{
        static void s390xHw()
        {
                int a=1, b=0, c=1;
                b = a - c;
        }
        public static void Main(string []args)
        {
                s390xHw();
        }
}
```

dump:
```
IN0001:  00000000`00000000 00000C                    lgfi    r0, #0
IN0002:  00000000`00000000 000012                    st      	// [V00 loc0]
IN0003:  00000000`00000000 000016                    lgfi    r0, #0
IN0004:  00000000`00000000 00001C                    st      	// [V01 loc1]
IN0005:  00000000`00000000 000020                    lgfi    r0, #0
IN0006:  00000000`00000000 000026                    st      	// [V02 loc2]
IN0007:  00000000`00000000 00002A                    l       	// [V00 loc0]
IN0008:  00000000`00000000 00002E                    l       	// [V02 loc2]
IN0009:  00000000`00000000 000032                    srk     r0, r0, r1
IN000a:  00000000`00000000 000036                    st      	// [V01 loc1]
```