### PR TITLE
Cmp2

### DIFF
--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -4692,7 +4692,17 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
     GenTree*  op1 = tree->gtOp1;
     GenTree*  op2 = tree->gtOp2;
 
-    GetEmitter()->emitIns_R_R(INS_cr, EA_4BYTE, op1->GetRegNum(), op2->GetRegNum());
+    var_types op1Type = genActualType(op1->TypeGet());
+    emitAttr cmpSize = EA_ATTR(genTypeSize(op1Type));
+    bool isUnsigned = (tree->gtFlags & GTF_UNSIGNED) != 0;
+
+    instruction cmpIns;
+    if (cmpSize == EA_8BYTE)
+        cmpIns = isUnsigned ? INS_clgr : INS_cgr;
+    else
+        cmpIns = isUnsigned ? INS_clr : INS_cr;
+
+    GetEmitter()->emitIns_R_R(cmpIns, cmpSize, op1->GetRegNum(), op2->GetRegNum());
 
     if (targetReg != REG_NA)
     {

--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -4693,14 +4693,24 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
     GenTree*  op2 = tree->gtOp2;
 
     var_types op1Type = genActualType(op1->TypeGet());
-    emitAttr cmpSize = EA_ATTR(genTypeSize(op1Type));
-    bool isUnsigned = (tree->gtFlags & GTF_UNSIGNED) != 0;
 
     instruction cmpIns;
-    if (cmpSize == EA_8BYTE)
-        cmpIns = isUnsigned ? INS_clgr : INS_cgr;
+    emitAttr cmpSize;
+
+    if (varTypeIsFloating(op1Type))
+    {
+        cmpIns = (op1Type == TYP_FLOAT) ? INS_cebr : INS_cdbr;
+        cmpSize = (op1Type == TYP_FLOAT) ? EA_4BYTE : EA_8BYTE;
+    }
     else
-        cmpIns = isUnsigned ? INS_clr : INS_cr;
+    {
+        cmpSize = EA_ATTR(genTypeSize(op1Type));
+        bool isUnsigned = (tree->gtFlags & GTF_UNSIGNED) != 0;
+        if (cmpSize == EA_8BYTE)
+            cmpIns = isUnsigned ? INS_clgr : INS_cgr;
+        else
+            cmpIns = isUnsigned ? INS_clr : INS_cr;
+    }
 
     GetEmitter()->emitIns_R_R(cmpIns, cmpSize, op1->GetRegNum(), op2->GetRegNum());
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1189,6 +1189,7 @@ protected:
                 case INS_br:
                 case INS_nop:
                 case INS_cr:
+		case INS_clr:
                     size = 2;
                     break;
                 case INS_lgfi:

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -3836,6 +3836,9 @@ void emitter::emitIns_R_R(instruction     ins,
     switch (ins)
     {
 	case INS_cr:
+    	case INS_cgr:
+    	case INS_clr:
+    	case INS_clgr:
             fmt = IF_DR_2E;
             break;
 #if 0
@@ -10255,8 +10258,15 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         break;
 
         case INS_cr:
+        case INS_clr:
             op = emitInsCode(ins, fmt);
             S390_RR(dst, op, id->idReg1(), id->idReg2());
+            break;
+
+        case INS_cgr:
+        case INS_clgr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, id->idReg1(), id->idReg2());
             break;
 
         case INS_j:

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -3839,6 +3839,8 @@ void emitter::emitIns_R_R(instruction     ins,
     	case INS_cgr:
     	case INS_clr:
     	case INS_clgr:
+	case INS_cebr:
+	case INS_cdbr:
             fmt = IF_DR_2E;
             break;
 #if 0
@@ -10286,6 +10288,16 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             break;
 
         case INS_aebr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
+            break;
+
+	case INS_cebr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
+            break;
+
+	case INS_cdbr:
             op = emitInsCode(ins, fmt);
             S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
             break;

--- a/src/coreclr/jit/instrss390x.h
+++ b/src/coreclr/jit/instrss390x.h
@@ -138,6 +138,9 @@ INST(lgr,		"lgr",			0,		0xb904)
 
 //// Compare (RR format - 2 bytes, sets condition code)
 INST(cr,            "cr",             0,    0x19)
+INST(cgr,       "cgr",          0,      0xB920)
+INST(clr,       "clr",          0,      0x15)
+INST(clgr,      "clgr",         0,      0xB921)
 
 //// Conditional Branch (all use BRCL opcode 0xC04, RIL format, 6 bytes)
 INST(j,             "brcl",           0,    0xC04)

--- a/src/coreclr/jit/instrss390x.h
+++ b/src/coreclr/jit/instrss390x.h
@@ -61,6 +61,8 @@ INST(clgebr,    "clgebr",       0,      0xb3ac)
 INST(clgdbr,    "clgdbr",       0,      0xb3ad)
 INST(ldebr,     "ldebr",        0,      0xb304)
 INST(ledbr,     "ledbr",        0,      0xb344)
+INST(cebr,      "cebr",         0,      0xb309)
+INST(cdbr,      "cdbr",         0,      0xb319)
 
 ////R_I
 INST(llgc,		"llgc",			0,		0xe390)


### PR DESCRIPTION
comparison support for uint/long/ulong and float/double


### For uint/ulong
```
class HelloWorld {
    static void s390xHw() {
        uint a = 3, c = 2, r = 0;
        if (a > c) r = 1;
        ulong x = 3, y = 2, s = 0;
        if (x > y) s = 1;
    }
    public static void Main(string[] args) { s390xHw(); }
}
```
disass dump:
gdb) disass (dst+writeableOffset-200), (dst+writeableOffset)
Dump of assembler code from 0x2aa001a0068 to 0x2aa001a0130:
   0x000002aa001a0068:  cr      %r1,%r2
   0x000002aa001a006a:  jge     0x2aa001a0070
   0x000002aa001a0070:  nopr
   0x000002aa001a0072:  lgfi    %r1,3
   0x000002aa001a0078:  st      %r1,164(%r15)
   0x000002aa001a007c:  lgfi    %r1,2
   0x000002aa001a0082:  st      %r1,168(%r15)
   0x000002aa001a0086:  lgfi    %r1,0
   0x000002aa001a008c:  st      %r1,172(%r15)
   0x000002aa001a0090:  l       %r1,164(%r15)
   0x000002aa001a0094:  l       %r2,168(%r15)
   0x000002aa001a0098:  clr     %r1,%r2
   0x000002aa001a009a:  lgfi    %r1,1
   0x000002aa001a00a0:  jgh     0x2aa001a00ac
   0x000002aa001a00a6:  lgfi    %r1,0
   0x000002aa001a00ac:  st      %r1,212(%r15)
   0x000002aa001a00b0:  l       %r1,212(%r15)
   0x000002aa001a00b4:  lgfi    %r2,0
   0x000002aa001a00ba:  cr      %r1,%r2
   0x000002aa001a00bc:  jge     0x2aa001a00cc
   0x000002aa001a00c2:  lgfi    %r1,1
   0x000002aa001a00c8:  st      %r1,172(%r15)
   0x000002aa001a00cc:  lgfi    %r1,3
   0x000002aa001a00d2:  st      %r1,192(%r15)
   0x000002aa001a00d6:  lgfi    %r1,2
   0x000002aa001a00dc:  st      %r1,200(%r15)
   0x000002aa001a00e0:  lgfi    %r1,0
   0x000002aa001a00e6:  st      %r1,208(%r15)
   0x000002aa001a00ea:  l       %r1,192(%r15)
   0x000002aa001a00ee:  l       %r2,200(%r15)
   0x000002aa001a00f2:  clgr    %r1,%r2
   0x000002aa001a00f6:  lgfi    %r1,1
   0x000002aa001a00fc:  jgh     0x2aa001a0108
   0x000002aa001a0102:  lgfi    %r1,0
   0x000002aa001a0108:  st      %r1,216(%r15)
   0x000002aa001a010c:  l       %r1,216(%r15)
   0x000002aa001a0110:  lgfi    %r2,0
   0x000002aa001a0116:  cr      %r1,%r2
   0x000002aa001a0118:  jge     0x2aa001a0128
   0x000002aa001a011e:  lgfi    %r1,1
   0x000002aa001a0124:  st      %r1,208(%r15)
   0x000002aa001a0128:  nopr
   0x000002aa001a012a:  lmg     %r11,%r15,312(%r15)
End of assembler dump.




#### For float/double

```
class HelloWorld {
    static void s390xHw() {
        float a = 3.0f, c = 2.0f, r = 0.0f;
        if (a > c) r = 1.0f;
        double x = 3.0, y = 2.0, s = 0.0;
        if (x > y) s = 1.0;
    }
    public static void Main(string[] args) { s390xHw(); }
}
```

disass dump:
Dump of assembler code from 0x2aa0024b092 to 0x2aa0024b15a:
   0x000002aa0024b092:  iihf    %r1,1023
   0x000002aa0024b098:  iilf    %r1,2012706096
   0x000002aa0024b09e:  l       %r1,0(%r1)
   0x000002aa0024b0a2:  lgfi    %r2,0
   0x000002aa0024b0a8:  cr      %r1,%r2
   0x000002aa0024b0aa:  jge     0x2aa0024b0b0
   0x000002aa0024b0b0:  nopr
   0x000002aa0024b0b2:  stey    %f0,164(%r15)
   0x000002aa0024b0b8:  stey    %f0,168(%r15)
   0x000002aa0024b0be:  lgfi    %r1,0
   0x000002aa0024b0c4:  ley     %f0,164(%r15)
   0x000002aa0024b0ca:  ley     %f1,168(%r15)
   0x000002aa0024b0d0:  cebr    %f0,%f1
   0x000002aa0024b0d4:  lgfi    %r1,1
   0x000002aa0024b0da:  jgh     0x2aa0024b0e6
   0x000002aa0024b0e0:  lgfi    %r1,0
   0x000002aa0024b0e6:  st      %r1,212(%r15)
   0x000002aa0024b0ea:  l       %r1,212(%r15)
   0x000002aa0024b0ee:  lgfi    %r2,0
   0x000002aa0024b0f4:  cr      %r1,%r2
   0x000002aa0024b0f6:  jge     0x2aa0024b102
   0x000002aa0024b0fc:  stey    %f0,172(%r15)
   0x000002aa0024b102:  stdy    %f0,192(%r15)
   0x000002aa0024b108:  stdy    %f0,200(%r15)
   0x000002aa0024b10e:  lgfi    %r1,0
   0x000002aa0024b114:  ldy     %f0,192(%r15)
   0x000002aa0024b11a:  ldy     %f1,200(%r15)
   0x000002aa0024b120:  cdbr    %f0,%f1
   0x000002aa0024b124:  lgfi    %r1,1
   0x000002aa0024b12a:  jgh     0x2aa0024b136
   0x000002aa0024b130:  lgfi    %r1,0
   0x000002aa0024b136:  st      %r1,216(%r15)
   0x000002aa0024b13a:  l       %r1,216(%r15)
   0x000002aa0024b13e:  lgfi    %r2,0
   0x000002aa0024b144:  cr      %r1,%r2
   0x000002aa0024b146:  jge     0x2aa0024b152
   0x000002aa0024b14c:  stdy    %f0,208(%r15)
   0x000002aa0024b152:  nopr
   0x000002aa0024b154:  lmg     %r11,%r15,312(%r15)
End of assembler dump.



NaN handling
```
class HelloWorld {
    static void s390xHw() {
        float nan = float.NaN;
        float x = 5.0f;
        int r1 = 0, r2 = 0, r3 = 0;
        if (nan != x)   r1 = 1; 
        if (nan != nan)  r2 = 1; 
        if (nan == nan)  r3 = 1;
    }
    public static void Main(string[] args) { s390xHw(); }
}
```

disass dump:
(gdb) disass (dst+writeableOffset-200), (dst+writeableOffset)
Dump of assembler code from 0x2aa000d4d52 to 0x2aa000d4e1a:
   0x000002aa000d4d52:  ley     %f1,168(%r15)
   0x000002aa000d4d58:  cebr    %f0,%f1
   0x000002aa000d4d5c:  lgfi    %r1,1
   0x000002aa000d4d62:  jgne    0x2aa000d4d6e
   0x000002aa000d4d68:  lgfi    %r1,0
   0x000002aa000d4d6e:  st      %r1,184(%r15)
   0x000002aa000d4d72:  l       %r1,184(%r15)
   0x000002aa000d4d76:  lgfi    %r2,0
   0x000002aa000d4d7c:  cr      %r1,%r2
   0x000002aa000d4d7e:  jge     0x2aa000d4d8e
   0x000002aa000d4d84:  lgfi    %r1,1
   0x000002aa000d4d8a:  st      %r1,172(%r15)
   0x000002aa000d4d8e:  ley     %f0,164(%r15)
   0x000002aa000d4d94:  ley     %f1,164(%r15)
   0x000002aa000d4d9a:  cebr    %f0,%f1
   0x000002aa000d4d9e:  lgfi    %r1,1
   0x000002aa000d4da4:  jgne    0x2aa000d4db0
   0x000002aa000d4daa:  lgfi    %r1,0
   0x000002aa000d4db0:  st      %r1,188(%r15)
   0x000002aa000d4db4:  l       %r1,188(%r15)
   0x000002aa000d4db8:  lgfi    %r2,0
   0x000002aa000d4dbe:  cr      %r1,%r2
   0x000002aa000d4dc0:  jge     0x2aa000d4dd0
   0x000002aa000d4dc6:  lgfi    %r1,1
   0x000002aa000d4dcc:  st      %r1,176(%r15)
   0x000002aa000d4dd0:  ley     %f0,164(%r15)
   0x000002aa000d4dd6:  ley     %f1,164(%r15)
   0x000002aa000d4ddc:  cebr    %f0,%f1
   0x000002aa000d4de0:  lgfi    %r1,1
   0x000002aa000d4de6:  jge     0x2aa000d4df2
   0x000002aa000d4dec:  lgfi    %r1,0
   0x000002aa000d4df2:  st      %r1,192(%r15)
   0x000002aa000d4df6:  l       %r1,192(%r15)
   0x000002aa000d4dfa:  lgfi    %r2,0
   0x000002aa000d4e00:  cr      %r1,%r2
   0x000002aa000d4e02:  jge     0x2aa000d4e12
   0x000002aa000d4e08:  lgfi    %r1,1
   0x000002aa000d4e0e:  st      %r1,180(%r15)
   0x000002aa000d4e12:  nopr
   0x000002aa000d4e14:  lmg     %r11,%r15,280(%r15)
End of assembler dump.