### PR TITLE
Add immediate compare instructions (CHI/CFI/CGFI/CLFI/CLGFI) 

### DIFF
--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -4714,11 +4714,25 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 
     instruction cmpIns;
     emitAttr cmpSize;
-
-    if (varTypeIsFloating(op1Type))
+    
+    if (op2->isContained() && op2->IsCnsIntOrI())
+    {
+        ssize_t imm = op2->AsIntCon()->gtIconVal;
+        bool isUnsigned = (tree->gtFlags & GTF_UNSIGNED) != 0;
+        cmpSize = EA_ATTR(genTypeSize(op1Type));
+        if (isUnsigned)
+            cmpIns = (cmpSize == EA_8BYTE) ? INS_clgfi : INS_clfi;
+        else if (imm >= -32768 && imm <= 32767)
+	    cmpIns = (cmpSize == EA_8BYTE) ? INS_cgfi : INS_chi;
+	else
+            cmpIns = (cmpSize == EA_8BYTE) ? INS_cgfi : INS_cfi;
+        GetEmitter()->emitIns_R_I(cmpIns, cmpSize, op1->GetRegNum(), imm);
+    }
+    else if (varTypeIsFloating(op1Type))
     {
         cmpIns = (op1Type == TYP_FLOAT) ? INS_cebr : INS_cdbr;
         cmpSize = (op1Type == TYP_FLOAT) ? EA_4BYTE : EA_8BYTE;
+        GetEmitter()->emitIns_R_R(cmpIns, cmpSize, op1->GetRegNum(), op2->GetRegNum());
     }
     else
     {
@@ -4728,9 +4742,8 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
             cmpIns = isUnsigned ? INS_clgr : INS_cgr;
         else
             cmpIns = isUnsigned ? INS_clr : INS_cr;
+            GetEmitter()->emitIns_R_R(cmpIns, cmpSize, op1->GetRegNum(), op2->GetRegNum());
     }
-
-    GetEmitter()->emitIns_R_R(cmpIns, cmpSize, op1->GetRegNum(), op2->GetRegNum());
 
     if (targetReg != REG_NA)
     {

--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -4724,7 +4724,7 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
             cmpIns = (cmpSize == EA_8BYTE) ? INS_clgfi : INS_clfi;
         else if (imm >= -32768 && imm <= 32767)
 	    cmpIns = (cmpSize == EA_8BYTE) ? INS_cgfi : INS_chi;
-	else
+	    else
             cmpIns = (cmpSize == EA_8BYTE) ? INS_cgfi : INS_cfi;
         GetEmitter()->emitIns_R_I(cmpIns, cmpSize, op1->GetRegNum(), imm);
     }

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1193,6 +1193,10 @@ protected:
                     size = 2;
                     break;
                 case INS_lgfi:
+                case INS_cfi:
+                case INS_cgfi:
+                case INS_clfi:
+                case INS_clgfi:
                 case INS_msfi:
                 case INS_msgfi:
                 case INS_afi:

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -3289,6 +3289,11 @@ void emitter::emitIns_R_I(instruction ins,
         case INS_lgfi:
         case INS_iihf:
         case INS_iilf:
+        case INS_chi:
+        case INS_cfi:
+        case INS_cgfi:
+        case INS_clfi:
+        case INS_clgfi:
             assert(isValidGeneralDatasize(size));
             assert(insOptsNone(opt)); // No explicit LSL here
             // We will automatically determine the shift based upon the imm
@@ -10212,7 +10217,37 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
-        case INS_nop:
+        case INS_cfi:
+            imm = emitGetInsSC(id);
+            op = emitInsCode(ins, fmt);
+            S390_RIL_a(dst, op, id->idReg1(), imm);
+            break;
+
+        case INS_cgfi:
+            imm = emitGetInsSC(id);
+            op = emitInsCode(ins, fmt);
+            S390_RIL_a(dst, op, id->idReg1(), imm);
+            break;
+
+        case INS_clfi:
+            imm = emitGetInsSC(id);
+            op = emitInsCode(ins, fmt);
+            S390_RIL_a(dst, op, id->idReg1(), imm);
+            break;
+
+        case INS_clgfi:
+            imm = emitGetInsSC(id);
+            op = emitInsCode(ins, fmt);
+            S390_RIL_a(dst, op, id->idReg1(), imm);
+            break;
+
+        case INS_chi:
+            imm = emitGetInsSC(id);
+            op = emitInsCode(ins, fmt);
+            S390_RI_a(dst, op, id->idReg1(), imm);
+            break;
+
+	case INS_nop:
             op = emitInsCode(ins, fmt);
             S390_RR(dst, op, 0, 0);
             break;

--- a/src/coreclr/jit/emits390x.h
+++ b/src/coreclr/jit/emits390x.h
@@ -67,6 +67,13 @@ static bool strictArmAsm;
 	dst += emitOutputLong (dst, i2);					\
 }										\
 
+#define S390_RI_a(dst, opc, r1, i2)						\
+{										\
+	dst += emitOutputWord (dst, (((opc >> 4) << 8) | (r1 << 4) |		\
+			      (opc & 0xf)));					\
+	dst += emitOutputWord (dst, ((i2) & 0xffff));				\
+}
+
 #define S390_RI(dst, opc, r1, r2)						\
 {										\
 	dst += emitOutputLong (dst, ((opc >> 4) << 24 | (r1) << 20 | (opc & 0x0f) << 16 | (r2 & 0xffff)));		\

--- a/src/coreclr/jit/instrss390x.h
+++ b/src/coreclr/jit/instrss390x.h
@@ -156,6 +156,12 @@ INST(cgr,       "cgr",          0,      0xB920)
 INST(clr,       "clr",          0,      0x15)
 INST(clgr,      "clgr",         0,      0xB921)
 
+INST(chi,       "chi",          0,      0xa7e)
+INST(cfi,       "cfi",          0,      0xc2d)
+INST(cgfi,      "cgfi",         0,      0xc2c)
+INST(clfi,      "clfi",         0,      0xc2f)
+INST(clgfi,     "clgfi",        0,      0xc2e)
+
 //// Conditional Branch (all use BRCL opcode 0xC04, RIL format, 6 bytes)
 INST(j,             "brcl",           0,    0xC04)
 INST(beq,           "brcl",           0,    0xC04)

--- a/src/coreclr/jit/lowers390x.cpp
+++ b/src/coreclr/jit/lowers390x.cpp
@@ -51,6 +51,21 @@ bool Lowering::IsCallTargetInRange(void* addr)
 //
 bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
 {
+    // s390x: Enable immediate containment for compare operations
+    if (!childNode->IsCnsIntOrI())
+        return false;
+    if (childNode->AsIntCon()->ImmedValNeedsReloc(comp))
+        return false;
+    if (parentNode->OperIsCompare())
+    {
+        ssize_t val = childNode->AsIntCon()->gtIconVal;
+        if (val >= INT32_MIN && val <= INT32_MAX)
+            return true;
+        if (val >= 0 && (uint64_t)val <= UINT32_MAX)
+            return true;
+    }
+    return false;
+#if 0
     if (!varTypeIsFloating(parentNode->TypeGet()))
     {
         if (parentNode->OperIsCompare() && childNode->IsFloatPositiveZero())
@@ -142,6 +157,7 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
     }
 
     return false;
+#endif
 }
 
 //------------------------------------------------------------------------
@@ -2961,6 +2977,38 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
 //#if 0 
     GenTree* op1 = cmp->gtGetOp1();
     GenTree* op2 = cmp->gtGetOp2();
+
+    // s390x: Fold widening cast of constants to enable CGFI/CLGFI.
+    if (op2->OperIs(GT_CAST) && !op2->gtOverflow() && varTypeIsLong(op2->TypeGet()))
+    {
+        GenTree* castOp = op2->AsCast()->CastOp();
+        if (castOp->IsCnsIntOrI() && !castOp->AsIntCon()->ImmedValNeedsReloc(comp))
+        {
+            ssize_t val = castOp->AsIntCon()->gtIconVal;
+            if (val >= INT32_MIN && val <= INT32_MAX)
+            {
+                castOp->gtType = TYP_LONG;
+                BlockRange().Remove(op2);
+                cmp->gtOp2 = castOp;
+                op2 = castOp;
+            }
+        }
+    }
+    if (op1->OperIs(GT_CAST) && !op1->gtOverflow() && varTypeIsLong(op1->TypeGet()))
+    {
+        GenTree* castOp = op1->AsCast()->CastOp();
+        if (castOp->IsCnsIntOrI() && !castOp->AsIntCon()->ImmedValNeedsReloc(comp))
+        {
+            ssize_t val = castOp->AsIntCon()->gtIconVal;
+            if (val >= INT32_MIN && val <= INT32_MAX)
+            {
+                castOp->gtType = TYP_LONG;
+                BlockRange().Remove(op1);
+                cmp->gtOp1 = castOp;
+                op1 = castOp;
+            }
+        }
+    }
 
     if (CheckImmedAndMakeContained(cmp, op2))
         return;


### PR DESCRIPTION
also includes cast folding because when comparing a long variable with a small constant (e.g., `long x > 2`),the C# compiler encodes the constant 2 as a 32-bit int in the IL bytecode and adds a conversion to 64-bit. This is more compact than encoding a full 64-bit constant (2 bytes vs 9 bytes in IL). However, this means the JIT sees a CAST node wrapping the constant instead of the constant directly. The lowering phase checks if the operand is a constant to decide whether
to use an immediate compare instruction, but since the operand is a CAST node and not a constant, the check fails and the JIT falls back to loading the constant into a register and doing a register-register compare. This change adds detection of this pattern in ContainCheckCompare, folding the cast away and allowing CGFI/CLGFI to be emitted. This is safe because
CGFI already sign-extends its 32-bit immediate to 64-bit internally, which is exactly what the cast does.


Program
```
class HelloWorld {
    static void s390xHw() {
        int a = 3;
        if (a > 2) a = 1;
        long x = 3;
        if (x > 2) x = 1;
        uint u = 3;
        if (u > 2) u = 1;
        ulong y = 3;
        if (y > 2) y = 1;
    }
    public static void Main(string[] args) { s390xHw(); }
}

```
disass dump


0x000002aa002247b8: trtr  3328(12,%r14),3792(%r11)                                                                                               
  0x000002aa002247be: bsm   %r10,%r10                                                                                                      
  0x000002aa002247c0: trtr  3328(12,%r14),3792(%r11)                                                                                               
  0x000002aa002247c6: bsm   %r10,%r10                                                                                                      
  0x000002aa002247c8: .long  0x00000000                                                                                                      
  0x000002aa002247cc: .long  0x00000161                                                                                                      
  0x000002aa002247d0: .long  0x000003ff                                                                                                      
  0x000002aa002247d4: .long  0x77f94360                                                                                                      
  0x000002aa002247d8: stmg  %r11,%r15,88(%r15)                                                                                                  
  0x000002aa002247de: lgr   %r11,%r15                                                                                                      
  0x000002aa002247e2: lay   %r15,-224(%r15)                                                                                                   
  0x000002aa002247e8: stg   %r11,0(%r15)                                                                                                     
  0x000002aa002247ee: lgr   %r11,%r15                                                                                                      
  0x000002aa002247f2: iihf  %r1,1023                                                                                                       
  0x000002aa002247f8: iilf  %r1,2012640560                                                                                                    
  0x000002aa002247fe: l    %r1,0(%r1)                                                                                                      
  0x000002aa00224802: chi   %r1,0                                                                                                        
  0x000002aa00224806: jge   0x2aa0022480c
  0x000002aa0022480c: nopr
  0x000002aa0022480e: lgfi  %r1,3
  0x000002aa00224814: st   %r1,164(%r15)
  0x000002aa00224818: l    %r1,164(%r15)
  0x000002aa0022481c: chi   %r1,2
  0x000002aa00224820: lgfi  %r1,1
  0x000002aa00224826: jgh   0x2aa00224832
  0x000002aa0022482c: lgfi  %r1,0
  0x000002aa00224832: st   %r1,212(%r15)
  0x000002aa00224836: l    %r1,212(%r15)
  0x000002aa0022483a: chi   %r1,0
  0x000002aa0022483e: jge   0x2aa0022484e
  0x000002aa00224844: lgfi  %r1,1
  0x000002aa0022484a: st   %r1,164(%r15)
  0x000002aa0022484e: lgfi  %r1,3
  0x000002aa00224854: st   %r1,184(%r15)
  0x000002aa00224858: l    %r1,184(%r15)
  0x000002aa0022485c: cgfi  %r1,2
  0x000002aa00224862: lgfi  %r1,1
  0x000002aa00224868: jgh   0x2aa00224874
  0x000002aa0022486e: lgfi  %r1,0
  0x000002aa00224874: st   %r1,216(%r15)
  0x000002aa00224878: l    %r1,216(%r15)
  0x000002aa0022487c: chi   %r1,0
  0x000002aa00224880: jge   0x2aa00224890
  0x000002aa00224886: lgfi  %r1,1
  0x000002aa0022488c: st   %r1,184(%r15)
  0x000002aa00224890: lgfi  %r1,3
  0x000002aa00224896: st   %r1,188(%r15)
  0x000002aa0022489a: l    %r1,188(%r15)
  0x000002aa0022489e: clfi  %r1,2
  0x000002aa002248a4: lgfi  %r1,1
  0x000002aa002248aa: jgh   0x2aa002248b6
  0x000002aa002248b0: lgfi  %r1,0
  0x000002aa002248b6: st   %r1,220(%r15)
  0x000002aa002248ba: l    %r1,220(%r15)
--Type <RET> for more, q to quit, c to continue without paging--
  0x000002aa002248be: chi   %r1,0
  0x000002aa002248c2: jge   0x2aa002248d2
  0x000002aa002248c8: lgfi  %r1,1
  0x000002aa002248ce: st   %r1,188(%r15)
  0x000002aa002248d2: lgfi  %r1,3
  0x000002aa002248d8: st   %r1,208(%r15)
  0x000002aa002248dc: l    %r1,208(%r15)
  0x000002aa002248e0: clgfi  %r1,2
  0x000002aa002248e6: lgfi  %r1,1
  0x000002aa002248ec: jgh   0x2aa002248f8
  0x000002aa002248f2: lgfi  %r1,0
0x000002aa002248f8: st   %r1,224(%r15)
  0x000002aa002248fc: l    %r1,224(%r15)
  0x000002aa00224900: chi   %r1,0
  0x000002aa00224904: jge   0x2aa00224914
  0x000002aa0022490a: lgfi  %r1,1
  0x000002aa00224910: st   %r1,208(%r15)
  0x000002aa00224914: nopr
  0x000002aa00224916: lmg   %r11,%r15,312(%r15)
End of assembler dump.