### PR TITLE
Adding support for GT_DIV, GT_UDIV, GT_UMOD, GT_MOD operations 

### DIFF
--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -349,7 +349,62 @@ void CodeGen::genCodeForLclVar(GenTreeLclVar* tree)
         emit->emitIns_R_S(ins, attr, tree->GetRegNum(), varNum, 0);
         genProduceReg(tree);
     }
-}              
+}
+
+//------------------------------------------------------------------------
+// genCodeForDivMod: Produce code for a GT_DIV/GT_UDIV/GT_MOD/GT_UMOD node.
+//
+// Arguments:
+//    tree - the node
+//
+void CodeGen::genCodeForDivMod(GenTreeOp* tree)
+{
+    assert(tree->OperIs(GT_DIV, GT_UDIV, GT_MOD, GT_UMOD));
+
+    emitter*  emit       = GetEmitter();
+    emitAttr  attr       = emitActualTypeSize(tree);
+    regNumber targetReg  = tree->GetRegNum();
+    GenTree*  src1       = tree->gtGetOp1();
+    GenTree*  src2       = tree->gtGetOp2();
+    regNumber divisorReg = src2->GetRegNum();
+
+    // Fixed even/odd pair
+    regNumber dividendEven = REG_R0;
+    regNumber dividendOdd  = REG_R1;
+
+    noway_assert(targetReg != REG_NA);
+
+    genConsumeOperands(tree);
+
+    instruction ins = genGetInsForOper(tree);
+
+    if (ins == INS_dr)
+    {
+        // 32-bit signed: load into odd, SRDA from even to sign-extend
+        emit->emitIns_R_R(INS_lgr,  attr,     dividendOdd,  src1->GetRegNum());
+        emit->emitIns_R_I(INS_srda, EA_8BYTE, dividendEven, 32);
+    }
+    else if (ins == INS_dsgr)
+    {
+        emit->emitIns_R_R(INS_lgr, EA_8BYTE, dividendOdd, src1->GetRegNum());
+    }
+    else
+    {
+        emit->emitIns_R_I(INS_lgfi, EA_8BYTE, dividendEven, 0);
+        emit->emitIns_R_R(INS_lgr,  attr,     dividendOdd,  src1->GetRegNum());
+    }
+
+    emit->emitIns_R_R(ins, attr, dividendEven, divisorReg);
+
+    regNumber resultReg    = tree->OperIs(GT_DIV, GT_UDIV) ? dividendOdd : dividendEven;
+
+    if (targetReg != resultReg)
+    {
+        emit->emitIns_R_R(INS_lgr, EA_8BYTE, targetReg, resultReg);
+    }
+
+    genProduceReg(tree);
+}
 //------------------------------------------------------------------------
 // genCodeForTreeNode Generate code for a single node in the tree.
 //
@@ -447,12 +502,12 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
                 break;
             }
             FALLTHROUGH;
-//        case GT_MOD:
-//        case GT_UMOD:
-//        case GT_UDIV:
-//            genCodeForDivMod(treeNode->AsOp());
-//            break;
-//
+        case GT_MOD:
+        case GT_UMOD:
+        case GT_UDIV:
+            genCodeForDivMod(treeNode->AsOp());
+            break;
+
         case GT_OR:
         case GT_XOR:
         case GT_AND:
@@ -4848,55 +4903,33 @@ instruction CodeGen::genGetInsForOper(GenTree* treeNode)
                 ins = INS_srk;
             }
             break;
-/*
-        case GT_MOD:
-            if ((attr == EA_8BYTE) || (attr == EA_BYREF))
-            {
-                ins = INS_mod_d;
-            }
-            else
-            {
-                assert(attr == EA_4BYTE);
-                ins = INS_mod_w;
-            }
-            break;
 
+        case GT_MOD:
         case GT_DIV:
             if ((attr == EA_8BYTE) || (attr == EA_BYREF))
             {
-                ins = INS_div_d;
+                ins = INS_dsgr;
             }
             else
             {
                 assert(attr == EA_4BYTE);
-                ins = INS_div_w;
+                ins = INS_dr;
             }
             break;
 
         case GT_UMOD:
-            if ((attr == EA_8BYTE) || (attr == EA_BYREF))
-            {
-                ins = INS_mod_du;
-            }
-            else
-            {
-                assert(attr == EA_4BYTE);
-                ins = INS_mod_wu;
-            }
-            break;
-
         case GT_UDIV:
             if ((attr == EA_8BYTE) || (attr == EA_BYREF))
             {
-                ins = INS_div_du;
+                ins = INS_dlgr;
             }
             else
             {
                 assert(attr == EA_4BYTE);
-                ins = INS_div_wu;
+                ins = INS_dlr;
             }
             break;
-*/
+
 
         case GT_MUL:
             isImm = isImmed(treeNode);

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1189,7 +1189,8 @@ protected:
                 case INS_br:
                 case INS_nop:
                 case INS_cr:
-		case INS_clr:
+                case INS_clr:
+                case INS_dr:
                     size = 2;
                     break;
                 case INS_lgfi:

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -3840,13 +3840,20 @@ void emitter::emitIns_R_R(instruction     ins,
     /* Figure out the encoding format of the instruction */
     switch (ins)
     {
-	case INS_cr:
-    	case INS_cgr:
-    	case INS_clr:
-    	case INS_clgr:
-	case INS_cebr:
-	case INS_cdbr:
+        case INS_cr:
+        case INS_cgr:
+        case INS_clr:
+        case INS_clgr:
+        case INS_cebr:
+        case INS_cdbr:
             fmt = IF_DR_2E;
+            break;
+
+        case INS_dr:
+        case INS_dsgr:
+        case INS_dlr:
+        case INS_dlgr:
+            assert((reg1 & 1) == 0 && "R1 must be even");
             break;
 #if 0
         case INS_dup:
@@ -10499,6 +10506,32 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             imm = emitGetInsSC(id);
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
+            break;
+
+        case INS_dr:
+            op = emitInsCode(ins, fmt);
+            S390_RR(dst, op, id->idReg1(), id->idReg2());
+            break;
+
+        case INS_dsgr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, id->idReg1(), id->idReg2());
+            break;
+
+        case INS_dlr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, id->idReg1(), id->idReg2());
+            break;
+
+        case INS_dlgr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, id->idReg1(), id->idReg2());
+            break;
+
+        case INS_srda:
+            imm = emitGetInsSC(id);
+            op  = emitInsCode(ins, fmt);
+            S390_RS_a(dst, op, id->idReg1(), 0, 0, imm);
             break;
 
         default:

--- a/src/coreclr/jit/emits390x.h
+++ b/src/coreclr/jit/emits390x.h
@@ -79,6 +79,11 @@ static bool strictArmAsm;
 	dst += emitOutputLong (dst, ((opc >> 4) << 24 | (r1) << 20 | (opc & 0x0f) << 16 | (r2 & 0xffff)));		\
 }										\
 
+#define S390_RS_a(dst, opc, r1, r3, b2, d2)                    \
+{                                       \
+    dst += emitOutputLong(dst, ((opc << 24) | ((r1) << 20) |((r3) << 16) | ((b2) << 12) | ((d2) & 0xfff)));    \
+}
+
 /************************************************************************/
 /*         Routines that compute the size of / encode instructions      */
 /************************************************************************/

--- a/src/coreclr/jit/instrss390x.h
+++ b/src/coreclr/jit/instrss390x.h
@@ -63,6 +63,10 @@ INST(ldebr,     "ldebr",        0,      0xb304)
 INST(ledbr,     "ledbr",        0,      0xb344)
 INST(cebr,      "cebr",         0,      0xb309)
 INST(cdbr,      "cdbr",         0,      0xb319)
+INST(dr,        "dr",           0,      0x1d)
+INST(dsgr,      "dsgr",         0,      0xb90d)
+INST(dlr,       "dlr",          0,      0xb997)
+INST(dlgr,      "dlgr",         0,      0xb987)
 
 ////R_I
 INST(llgc,		"llgc",			0,		0xe390)
@@ -89,6 +93,7 @@ INST(st,		"st",			0,		0x50)
 INST(stg,		"stg",			0,		0xe324)
 INST(std,		"std",			0,		0x60)
 INST(lay,		"lay",			0,		0xe371)
+INST(srda,      "srda",         0,      0x8e)
 
 //// R_R_R
 INST(ark,		"ark",			0,		0xb9f8)

--- a/src/coreclr/jit/lowers390x.cpp
+++ b/src/coreclr/jit/lowers390x.cpp
@@ -2858,7 +2858,7 @@ void Lowering::ContainCheckMul(GenTreeOp* node)
 //
 void Lowering::ContainCheckDivOrMod(GenTreeOp* node)
 {
-    assert(node->OperIs(GT_DIV, GT_UDIV, GT_MOD));
+    assert(node->OperIs(GT_DIV, GT_UDIV, GT_MOD, GT_UMOD));
     // S390X doesnot have a div with immediate 
 }
 

--- a/src/coreclr/jit/lsras390x.cpp
+++ b/src/coreclr/jit/lsras390x.cpp
@@ -1670,9 +1670,11 @@ int LinearScan::BuildNode(GenTree* tree)
 
         case GT_MOD:
         case GT_UMOD:
-            NYI_IF(varTypeIsFloating(tree->TypeGet()), "FP Remainder in ARM64");
-            assert(!"Shouldn't see an integer typed GT_MOD node in ARM64");
-            srcCount = 0;
+            NYI_IF(varTypeIsFloating(tree->TypeGet()), "FP Remainder in s390");
+            srcCount = BuildBinaryUses(tree->AsOp());
+            buildInternalRegisterUses();
+            assert(dstCount == 1);
+            BuildDef(tree);
             break;
 
         case GT_MUL:


### PR DESCRIPTION
This PR implements code generation for integer divide and mod operations (dr, dlr, dsgr, dlgr)

hardcoded even/odd register pair as R0/R1 temporarily.
DR  (32-bit signed):   sign-extend using  SRDA into R0:R1
DSGR (64-bit signed):  load dividend into odd register only
DLR/DLGR (unsigned):   zero R0, load dividend into R1
placed quotient in odd register and remainder in even register.

Output:
```
0x000002aa0011af3e:	lgr	%r11,%r15
   0x000002aa0011af42:	lay	%r15,-304(%r15)
   0x000002aa0011af48:	stg	%r11,0(%r15)
   0x000002aa0011af4e:	lgr	%r11,%r15
   0x000002aa0011af52:	iihf	%r1,1023
   0x000002aa0011af58:	iilf	%r1,2010608944
   0x000002aa0011af5e:	l	%r1,0(%r1)
   0x000002aa0011af62:	chi	%r1,0
   0x000002aa0011af66:	jge	0x2aa0011af6c
   0x000002aa0011af6c:	nopr
   0x000002aa0011af6e:	lgfi	%r1,100
   0x000002aa0011af74:	st	%r1,164(%r15)
   0x000002aa0011af78:	lgfi	%r1,0
   0x000002aa0011af7e:	st	%r1,168(%r15)
   0x000002aa0011af82:	lgfi	%r1,7
   0x000002aa0011af88:	st	%r1,172(%r15)
   0x000002aa0011af8c:	l	%r1,164(%r15)
   0x000002aa0011af90:	l	%r2,172(%r15)
   0x000002aa0011af94:	lgr	%r1,%r1
   0x000002aa0011af98:	srda	%r0,32
   0x000002aa0011af9c:	dr	%r0,%r2
```
```
0x000002aa0010e938:	srp	17(16,%r12),0,12
   0x000002aa0010e93e:	.long	0x00075010
   0x000002aa0010e942:	mvo	2064(1,%r5),248(1,%r15)
   0x000002aa0010e948:	l	%r2,256(%r15)
   0x000002aa0010e94c:	lgfi	%r0,0
   0x000002aa0010e952:	lgr	%r1,%r1
   0x000002aa0010e956:	dlr	%r0,%r2
   0x000002aa0010e95a:	lgr	%r1,%r0
   0x000002aa0010e95e:	st	%r1,252(%r15)
   0x000002aa0010e962:	iihf	%r1,2
   0x000002aa0010e968:	iilf	%r1,1410065408
   0x000002aa0010e96e:	st	%r1,264(%r15)
   0x000002aa0010e972:	lgfi	%r1,0
   0x000002aa0010e978:	st	%r1,272(%r15)
   0x000002aa0010e97c:	lgfi	%r1,13
   0x000002aa0010e982:	st	%r1,280(%r15)
   0x000002aa0010e986:	l	%r1,264(%r15)
   0x000002aa0010e98a:	l	%r2,280(%r15)
   0x000002aa0010e98e:	lgfi	%r0,0
   0x000002aa0010e994:	lgr	%r1,%r1
   0x000002aa0010e998:	dlgr	%r0,%r2
```
```
   0x000002aa001180de:	n	%r0,1024(%r11,%r14)
   0x000002aa001180e2:	st	%r1,216(%r15)
   0x000002aa001180e6:	lgfi	%r1,0
   0x000002aa001180ec:	st	%r1,224(%r15)
   0x000002aa001180f0:	lgfi	%r1,13
   0x000002aa001180f6:	st	%r1,232(%r15)
   0x000002aa001180fa:	l	%r1,216(%r15)
   0x000002aa001180fe:	l	%r2,232(%r15)
   0x000002aa00118102:	lgr	%r1,%r1
   0x000002aa00118106:	dsgr	%r0,%r2
   0x000002aa0011810a:	st	%r1,224(%r15)
   0x000002aa0011810e:	lgfi	%r1,100
   0x000002aa00118114:	st	%r1,236(%r15)
   0x000002aa00118118:	lgfi	%r1,0
   0x000002aa0011811e:	st	%r1,240(%r15)
   0x000002aa00118122:	lgfi	%r1,7
   0x000002aa00118128:	st	%r1,244(%r15)
   0x000002aa0011812c:	l	%r1,236(%r15)
   0x000002aa00118130:	l	%r2,244(%r15)
   0x000002aa00118134:	lgfi	%r0,0
   0x000002aa0011813a:	lgr	%r1,%r1
   0x000002aa0011813e:	dlr	%r0,%r2
```
```
   0x000002aa0011839a:	srp	17(12,%r12),0,0
   0x000002aa001183a0:	.long	0x00005010
   0x000002aa001183a4:	srp	17(12,%r12),0,4
   0x000002aa001183aa:	.long	0x00075010
   0x000002aa001183ae:	srp	2064(12,%r5),176(%r15),8
   0x000002aa001183b4:	l	%r2,184(%r15)
   0x000002aa001183b8:	lgr	%r1,%r1
   0x000002aa001183bc:	srda	%r0,32
   0x000002aa001183c0:	dr	%r0,%r2
   0x000002aa001183c2:	lgr	%r1,%r0
   0x000002aa001183c6:	st	%r1,180(%r15)
   0x000002aa001183ca:	iihf	%r1,2
   0x000002aa001183d0:	iilf	%r1,1410065408
   0x000002aa001183d6:	st	%r1,192(%r15)
   0x000002aa001183da:	lgfi	%r1,0
   0x000002aa001183e0:	st	%r1,200(%r15)
   0x000002aa001183e4:	lgfi	%r1,13
   0x000002aa001183ea:	st	%r1,208(%r15)
   0x000002aa001183ee:	l	%r1,192(%r15)
   0x000002aa001183f2:	l	%r2,208(%r15)
   0x000002aa001183f6:	lgr	%r1,%r1
   0x000002aa001183fa:	dsgr	%r0,%r2
```