### PR TITLE
Fix Division, Multiplication and , Arithmetic left, right shift.

### DIFF
--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -380,13 +380,18 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
 
     if (ins == INS_dr)
     {
-        // 32-bit signed: load into odd, SRDA from even to sign-extend
-        emit->emitIns_R_R(INS_lgr,  attr,     dividendOdd,  src1->GetRegNum());
+        // 32-bit signed: load into even, SRDA to sign-extend
+        emit->emitIns_R_R(INS_lgfr,  EA_8BYTE, dividendEven,  src1->GetRegNum());
         emit->emitIns_R_I(INS_srda, EA_8BYTE, dividendEven, 32);
     }
     else if (ins == INS_dsgr)
     {
         emit->emitIns_R_R(INS_lgr, EA_8BYTE, dividendOdd, src1->GetRegNum());
+    }
+    else if(ins == INS_dlr)
+    {
+        emit->emitIns_R_R(INS_llgfr,  EA_8BYTE, dividendEven,  src1->GetRegNum());
+        emit->emitIns_R_I(INS_srdl, EA_8BYTE, dividendEven, 32);
     }
     else
     {
@@ -400,7 +405,14 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
 
     if (targetReg != resultReg)
     {
-        emit->emitIns_R_R(INS_lgr, EA_8BYTE, targetReg, resultReg);
+        if (attr == EA_4BYTE)
+        {
+            emit->emitIns_R_R(INS_lgfr, EA_8BYTE, targetReg, resultReg);
+        }
+        else
+        {
+            emit->emitIns_R_R(INS_lgr, EA_8BYTE, targetReg, resultReg);
+        }
     }
 
     genProduceReg(tree);
@@ -4948,11 +4960,11 @@ instruction CodeGen::genGetInsForOper(GenTree* treeNode)
             {
                 if ((attr == EA_8BYTE) || (attr == EA_BYREF))
                 {
-                    ins = INS_mul;
+                    ins = INS_msgrkc;
                 }
                 else
                 {
-                    ins = INS_msgrkc;
+                    ins = INS_mul;
                 }
             }
             break;

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1221,6 +1221,8 @@ protected:
                 case INS_ble:
                 case INS_blt:
                 case INS_bge:
+                case INS_sllg:
+                case INS_srag:
                     size = 6;
                     break;
                 default:

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -3846,6 +3846,8 @@ void emitter::emitIns_R_R(instruction     ins,
         case INS_clgr:
         case INS_cebr:
         case INS_cdbr:
+        case INS_lgfr:
+        case INS_llgfr:
             fmt = IF_DR_2E;
             break;
 
@@ -5492,6 +5494,7 @@ void emitter::emitIns_R_R_R(instruction     ins,
             break;
 #endif
         case INS_mul:
+        case INS_msgrkc:
         case INS_ark:
         case INS_agrk:
         case INS_srk:
@@ -10528,10 +10531,17 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             S390_RRE(dst, op, id->idReg1(), id->idReg2());
             break;
 
+        case INS_srdl:
         case INS_srda:
             imm = emitGetInsSC(id);
             op  = emitInsCode(ins, fmt);
             S390_RS_a(dst, op, id->idReg1(), 0, 0, imm);
+            break;
+
+        case INS_llgfr:
+        case INS_lgfr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, id->idReg1(), id->idReg2());
             break;
 
         default:

--- a/src/coreclr/jit/instrss390x.h
+++ b/src/coreclr/jit/instrss390x.h
@@ -67,6 +67,8 @@ INST(dr,        "dr",           0,      0x1d)
 INST(dsgr,      "dsgr",         0,      0xb90d)
 INST(dlr,       "dlr",          0,      0xb997)
 INST(dlgr,      "dlgr",         0,      0xb987)
+INST(llgfr,     "llgfr",        0,      0xb916)
+INST(lgfr,      "lgfr",         0,      0xb914)
 
 ////R_I
 INST(llgc,		"llgc",			0,		0xe390)
@@ -94,7 +96,7 @@ INST(stg,		"stg",			0,		0xe324)
 INST(std,		"std",			0,		0x60)
 INST(lay,		"lay",			0,		0xe371)
 INST(srda,      "srda",         0,      0x8e)
-
+INST(srdl,      "srdl",         0,      0x8c)
 //// R_R_R
 INST(ark,		"ark",			0,		0xb9f8)
 INST(agrk,		"agrk",			0,		0xb9e8)


### PR DESCRIPTION
Use LGFR for signed 32-bit DR preparation
Use LLGFR for unsigned 32-bit DLR preparation.
Use LGFR when materializing 32-bit div/mod results into the target register.
Fix instruction sizing for SLLG/SRAG.
Correct MUL/MSGRKC selection in genGetInsForOper.