### PR TITLE
Implement GT_CNS_DBL for s390x using LDGR approach

### DIFF
--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -170,7 +170,21 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
             regSet.verifyRegUsed(targetReg);
         }
         break;
-	default:
+	
+        case GT_CNS_DBL:
+        {
+            emitter*  emit       = GetEmitter();
+            double    constValue = tree->AsDblCon()->DconValue();
+            regNumber tmpReg     = internalRegisters.GetSingle(tree);
+        
+            int64_t bits = *reinterpret_cast<int64_t*>(&constValue);
+            instGen_Set_Reg_To_Imm(EA_8BYTE, tmpReg, bits);
+            emit->emitIns_R_R(INS_ldgr, EA_8BYTE, targetReg, tmpReg);
+        
+            regSet.verifyRegUsed(targetReg);
+        }
+        break;
+        default:
 		unreached();
     }
 }
@@ -523,7 +537,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 //            break;
 
         case GT_CNS_INT:
-//        case GT_CNS_DBL:
+        case GT_CNS_DBL:
 //        case GT_CNS_VEC:
 //        case GT_CNS_MSK:
             genSetRegToConst(targetReg, targetType, treeNode);

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -10210,13 +10210,13 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_ley:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-            S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
             break;
 
         case INS_ldy:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-            S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
             break;
 
         case INS_lgr:
@@ -10380,6 +10380,11 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
             break;
 
+        case INS_ldgr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2());
+            break;
+
         case INS_sebr:
             op = emitInsCode(ins, fmt);
             S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
@@ -10413,13 +10418,13 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_stey:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-            S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
             break;
 
         case INS_stdy:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-            S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
             break;
 
         case INS_cfebr:

--- a/src/coreclr/jit/instrss390x.h
+++ b/src/coreclr/jit/instrss390x.h
@@ -86,6 +86,7 @@ INST(ley,          "ley",                      0,              0xed64)
 INST(ldy,          "ldy",                      0,              0xed65)
 INST(stey,      "stey",         0,      0xed66)
 INST(stdy,      "stdy",         0,      0xed67)
+INST(ldgr,      "ldgr",         0,      0xb3c1)
 INST(xihf,      "xifh",         0,      0xc06)
 INST(nihf,      "nihf",         0,      0xc0a)
 

--- a/src/coreclr/jit/lsras390x.cpp
+++ b/src/coreclr/jit/lsras390x.cpp
@@ -1481,19 +1481,9 @@ int LinearScan::BuildNode(GenTree* tree)
 
         case GT_CNS_DBL:
         {
-            GenTreeDblCon* dblConst   = tree->AsDblCon();
-            double         constValue = dblConst->AsDblCon()->DconValue();
-
-            if (emitter::emitIns_valid_imm_for_fmov(constValue))
-            {
-                // Directly encode constant to instructions.
-            }
-            else
-            {
-                // Reserve int to load constant from memory (IF_LARGELDC)
-                buildInternalIntRegisterDefForNode(tree);
-                buildInternalRegisterUses();
-            }
+            // Reserve int to load constant from memory (IF_LARGELDC)
+            buildInternalIntRegisterDefForNode(tree);
+            buildInternalRegisterUses();
         }
             FALLTHROUGH;
 


### PR DESCRIPTION
## Summary
Implements `GT_CNS_DBL` (loading floating-point double constants) for s390x. 

Also fixes a FPR register encoding bug in `INS_ley`, `INS_ldy`, `INS_stey`, `INS_stdy`:  the JIT uses register numbers 16-31 for FPRs internally, but the hardware expects 0-15 in the instruction encoding.

## Test program
```csharp
using System;
class HelloWorld
{
    static double val;
    static void s390xHw() { val = 3.14; }
    public static void Main(string[] args) { s390xHw(); }
}
```
disass dump:

 
  ```
0x000002aa0029acf6:  .long   0x00000000
   0x000002aa0029acfa:  .long   0x03fff78c
   0x000002aa0029acfe:  .long   0xc8680000
   0x000002aa0029ad02:  .long   0x00000000
   0x000002aa0029ad06:  .long   0x00400000
   0x000002aa0029ad0a:  .long   0x00000000
   0x000002aa0029ad0e:  .long   0x00810000
   0x000002aa0029ad12:  .long   0x03ff77f9
   0x000002aa0029ad16:  ic      %r6,3007(%r14)
   0x000002aa0029ad1a:  srp     36(6,%r0),2308(%r11),8
   0x000002aa0029ad20:  .long   0x00bfe390
   0x000002aa0029ad24:  srp     36(2,%r0),1008(%r14),0
   0x000002aa0029ad2a:  .long   0xff58ff71
   0x000002aa0029ad2e:  stg     %r11,0(%r15)
   0x000002aa0029ad34:  lgr     %r11,%r15
   0x000002aa0029ad38:  iihf    %r1,1023
   0x000002aa0029ad3e:  iilf    %r1,2012640560
   0x000002aa0029ad44:  l       %r1,0(%r1)
   0x000002aa0029ad48:  chi     %r1,0
   0x000002aa0029ad4c:  jge     0x2aa0029ad52
   0x000002aa0029ad52:  nopr
   0x000002aa0029ad54:  iihf    %r1,1074339512
   0x000002aa0029ad5a:  iilf    %r1,1374389535
   0x000002aa0029ad60:  ldgr    %f0,%r1
   0x000002aa0029ad64:  iihf    %r1,1023
   0x000002aa0029ad6a:  iilf    %r1,2006168208
   0x000002aa0029ad70:  stdy    %f0,0(%r1)
   0x000002aa0029ad76:  nopr
   0x000002aa0029ad78:  lmg     %r11,%r15,256(%r15)
```

