### PR TITLE
Added support for genIntToIntCast

### DIFF
--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -3996,8 +3996,6 @@ void CodeGen::genIntCastOverflowCheck(GenTreeCast* cast, const GenIntCastDesc& d
 //
 void CodeGen::genIntToIntCast(GenTreeCast* cast)
 {
-    _ASSERTE("!NYI");
-#if 0
     genConsumeRegs(cast->CastOp());
 
     GenTree* const  src    = cast->CastOp();
@@ -4012,73 +4010,119 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
     if (desc.CheckKind() != GenIntCastDesc::CHECK_NONE)
     {
         assert(genIsValidIntReg(srcReg));
-        genIntCastOverflowCheck(cast, desc, srcReg);
+        //genIntCastOverflowCheck(cast, desc, srcReg);
+         NYI("genIntCastOverflowCheck for s390x");
     }
 
     if ((desc.ExtendKind() != GenIntCastDesc::COPY) || (srcReg != dstReg))
     {
         instruction ins;
-        unsigned    insSize;
+        emitAttr    attr;
 
         switch (desc.ExtendKind())
         {
             case GenIntCastDesc::ZERO_EXTEND_SMALL_INT:
-                ins     = (desc.ExtendSrcSize() == 1) ? INS_uxtb : INS_uxth;
-                insSize = 4;
+                if (desc.ExtendSrcSize() == 1)
+                {
+                    ins  = INS_llgcr;
+                    attr = EA_1BYTE;
+                }
+                else
+                {
+                    ins  = INS_llghr;
+                    attr = EA_2BYTE;
+                }
                 break;
             case GenIntCastDesc::SIGN_EXTEND_SMALL_INT:
-                ins     = (desc.ExtendSrcSize() == 1) ? INS_sxtb : INS_sxth;
-                insSize = 4;
+                if (desc.ExtendSrcSize() == 1)
+                {
+                    ins  = INS_lgbr;
+                    attr = EA_1BYTE;
+                }
+                else
+                {
+                    ins  = INS_lghr;
+                    attr = EA_2BYTE;
+                }
                 break;
 #ifdef TARGET_64BIT
             case GenIntCastDesc::ZERO_EXTEND_INT:
-                ins     = INS_mov;
-                insSize = 4;
+                ins  = INS_llgfr;
+                attr = EA_4BYTE;
                 break;
             case GenIntCastDesc::SIGN_EXTEND_INT:
-                ins     = INS_sxtw;
-                insSize = 8;
+                ins  = INS_lgfr;
+                attr = EA_4BYTE;
                 break;
 #endif // TARGET_64BIT
             case GenIntCastDesc::COPY:
-                ins     = INS_mov;
-                insSize = desc.ExtendSrcSize();
+                if (desc.ExtendSrcSize() == 4)
+                {
+                    ins  = INS_lr;
+                    attr = EA_4BYTE;
+                }
+                else
+                {
+                    ins  = INS_lgr;
+                    attr = EA_8BYTE;
+                }
                 break;
             case GenIntCastDesc::LOAD_ZERO_EXTEND_SMALL_INT:
-                ins     = (desc.ExtendSrcSize() == 1) ? INS_ldrb : INS_ldrh;
-                insSize = TARGET_POINTER_SIZE;
+                if (desc.ExtendSrcSize() == 1)
+                {
+                    ins  = INS_llgc;
+                    attr = EA_1BYTE;
+                }
+                else
+                {
+                    ins  = INS_llgh;
+                    attr = EA_2BYTE;
+                }
                 break;
             case GenIntCastDesc::LOAD_SIGN_EXTEND_SMALL_INT:
-                ins     = (desc.ExtendSrcSize() == 1) ? INS_ldrsb : INS_ldrsh;
-                insSize = TARGET_POINTER_SIZE;
+                if (desc.ExtendSrcSize() == 1)
+                {
+                    ins  = INS_lgb;
+                    attr = EA_1BYTE;
+                }
+                else
+                {
+                    ins  = INS_lgh;
+                    attr = EA_2BYTE;
+                }
                 break;
 #ifdef TARGET_64BIT
             case GenIntCastDesc::LOAD_ZERO_EXTEND_INT:
-                ins     = INS_ldr;
-                insSize = 4;
+                ins  = INS_llgf;
+                attr = EA_4BYTE;
                 break;
             case GenIntCastDesc::LOAD_SIGN_EXTEND_INT:
-                ins     = INS_ldrsw;
-                insSize = 8;
+                ins  = INS_lgf;
+                attr = EA_4BYTE;
                 break;
 #endif // TARGET_64BIT
             case GenIntCastDesc::LOAD_SOURCE:
-                ins     = ins_Load(src->TypeGet());
-                insSize = genTypeSize(genActualType(src));
+                if (desc.ExtendSrcSize() == 4)
+                {
+                    ins  = INS_l;
+                    attr = EA_4BYTE;
+                }
+                else
+                {
+                    ins  = INS_lg;
+                    attr = EA_8BYTE;
+                }
                 break;
-
             default:
                 unreached();
         }
 
         if (srcReg != REG_NA)
         {
-            emit->emitIns_Mov(ins, EA_ATTR(insSize), dstReg, srcReg, /* canSkip */ false);
+            GetEmitter()->emitIns_R_R(ins, attr, dstReg, srcReg);
         }
         else
         {
-            // The "used from memory" case. On ArmArch casts are the only nodes which can have
-            // contained memory operands, so we have to handle all possible sources "manually".
             assert(src->isUsedFromMemory());
 
             if (src->isUsedFromSpillTemp())
@@ -4089,24 +4133,23 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
                 unsigned tmpNum = tmpDsc->tdTempNum();
                 regSet.tmpRlsTemp(tmpDsc);
 
-                emit->emitIns_R_S(ins, EA_ATTR(insSize), dstReg, tmpNum, 0);
+                emit->emitIns_R_S(ins, attr, dstReg, tmpNum, 0);
             }
             else if (src->OperIsLocal())
             {
-                emit->emitIns_R_S(ins, EA_ATTR(insSize), dstReg, src->AsLclVarCommon()->GetLclNum(),
+                emit->emitIns_R_S(ins, attr, dstReg, src->AsLclVarCommon()->GetLclNum(),
                                   src->AsLclVarCommon()->GetLclOffs());
             }
             else
             {
                 assert(src->OperIs(GT_IND) && !src->AsIndir()->IsVolatile() && !src->AsIndir()->IsUnaligned());
-                emit->emitIns_R_R_I(ins, EA_ATTR(insSize), dstReg, src->AsIndir()->Base()->GetRegNum(),
+                emit->emitIns_R_R_I(ins, attr, dstReg, src->AsIndir()->Base()->GetRegNum(),
                                     static_cast<int>(src->AsIndir()->Offset()));
             }
         }
     }
 
     genProduceReg(cast);
-#endif
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1231,6 +1231,12 @@ protected:
                 case INS_srag:
                 case INS_srak:
                 case INS_sllk:
+                case INS_llgh:
+                case INS_lgh:
+                case INS_lgf:
+                case INS_llgc:
+                case INS_llgf:
+                case INS_lgb:
                     size = 6;
                     break;
                 default:

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -3848,6 +3848,12 @@ void emitter::emitIns_R_R(instruction     ins,
         case INS_cdbr:
         case INS_lgfr:
         case INS_llgfr:
+        case INS_llgcr:
+        case INS_llghr:
+        case INS_lgbr:
+        case INS_lghr:
+        case INS_lgr:
+        case INS_lr:
             fmt = IF_DR_2E;
             break;
 
@@ -10340,6 +10346,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             S390_RRF_a(dst, op, id->idReg3(), id->idReg1(), id->idReg2());
         break;
 
+        case INS_lr:
         case INS_cr:
         case INS_clr:
             op = emitInsCode(ins, fmt);
@@ -10568,6 +10575,10 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             S390_RS_a(dst, op, id->idReg1(), 0, 0, imm);
             break;
 
+        case INS_llgcr:
+        case INS_llghr:
+        case INS_lgbr:
+        case INS_lghr:
         case INS_llgfr:
         case INS_lgfr:
             op = emitInsCode(ins, fmt);
@@ -10600,6 +10611,16 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             imm = emitGetInsSC(id) & 0x3f;
             S390_RSY_a(dst, op, id->idReg1(), id->idReg2(), REG_NA, imm & 0x3f);
             break;
+
+        case INS_llgf:
+        case INS_llgc:
+        case INS_llgh:
+        case INS_lgb:
+        case INS_lgh:
+        case INS_lgf:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, id->idReg1(), id->idReg2());
+             break;
 
         default:
             _ASSERTE(!"NYI");

--- a/src/coreclr/jit/instrss390x.h
+++ b/src/coreclr/jit/instrss390x.h
@@ -71,6 +71,13 @@ INST(llgfr,     "llgfr",        0,      0xb916)
 INST(lgfr,      "lgfr",         0,      0xb914)
 INST(lcdbr,     "lcdbr",        0,      0xb313)
 INST(lcebr,     "lcebr",        0,      0xb303)
+INST(llgcr,     "llgcr",        0,      0xb984)
+INST(llghr,     "llghr",        0,      0xb985)
+INST(lgbr,      "lgbr",         0,      0xb906)
+INST(lghr,      "lghr",         0,      0xb907)
+INST(lr,        "lr",           0,      0x18)
+INST(llgf,      "llgf",         0,      0xe316)
+INST(lgf,       "lgf",          0,      0xe314)
 
 ////R_I
 INST(llgc,		"llgc",			0,		0xe390)


### PR DESCRIPTION
**Register-to-register extends:**
- Zero-extend small int: llgcr (8-bit), llghr (16-bit)
- Sign-extend small int: lgbr (8-bit), lghr (16-bit)
- Zero-extend 32→64: llgfr
- Sign-extend 32→64: lgfr
- Copy: lr (32-bit), lgr (64-bit)

**Contained-memory loads:**
- Zero-extend small int: llgc (8-bit), llgh (16-bit)
- Sign-extend small int: lgb (8-bit), lgh (16-bit)
- Zero-extend 32→64: llgf
- Sign-extend 32→64: lgf
- Load source: l (32-bit), lg (64-bit)


Overflow checking is left as NYI for now.