### PR TITLE
align integer argument register mapping with ABI (r2-r6)

### DIFF
--- a/src/coreclr/jit/targets390x.cpp
+++ b/src/coreclr/jit/targets390x.cpp
@@ -17,8 +17,8 @@ const Target::ArgOrder Target::g_tgtArgOrder          = ARG_ORDER_R2L;
 const Target::ArgOrder Target::g_tgtUnmanagedArgOrder = ARG_ORDER_R2L;
 
 // clang-format off
-const regNumber intArgRegs [] = {REG_R0, REG_R1, REG_R2, REG_R3, REG_R4, REG_R5, REG_R6, REG_R7};
-const regMaskTP intArgMasks[] = {RBM_R0, RBM_R1, RBM_R2, RBM_R3, RBM_R4, RBM_R5, RBM_R6, RBM_R7};
+const regNumber intArgRegs [] = {REG_R2, REG_R3, REG_R4, REG_R5, REG_R6};
+const regMaskTP intArgMasks[] = {RBM_R2, RBM_R3, RBM_R4, RBM_R5, RBM_R6};
 
 const regNumber fltArgRegs [] = {REG_V0, REG_V1, REG_V2, REG_V3, REG_V4, REG_V5, REG_V6, REG_V7 };
 const regMaskTP fltArgMasks[] = {RBM_V0, RBM_V1, RBM_V2, RBM_V3, RBM_V4, RBM_V5, RBM_V6, RBM_V7 };

--- a/src/coreclr/jit/targets390x.h
+++ b/src/coreclr/jit/targets390x.h
@@ -265,37 +265,31 @@
   //
   #define REG_ARG_RET_BUFF         REG_R8
   #define RBM_ARG_RET_BUFF         RBM_R8
-  #define RET_BUFF_ARGNUM          8
+  #define RET_BUFF_ARGNUM          5
 
-  #define MAX_REG_ARG              8
+  #define MAX_REG_ARG              5
   #define MAX_FLOAT_REG_ARG        8
 
-  #define REG_ARG_FIRST            REG_R0
-  #define REG_ARG_LAST             REG_R7
+  #define REG_ARG_FIRST            REG_R2
+  #define REG_ARG_LAST             REG_R6
   #define REG_ARG_FP_FIRST         REG_V0
   #define REG_ARG_FP_LAST          REG_V7
   #define INIT_ARG_STACK_SLOT      0                  // No outgoing reserved stack slots
 
-  #define REG_ARG_0                REG_R0
-  #define REG_ARG_1                REG_R1
-  #define REG_ARG_2                REG_R2
-  #define REG_ARG_3                REG_R3
-  #define REG_ARG_4                REG_R4
-  #define REG_ARG_5                REG_R5
-  #define REG_ARG_6                REG_R6
-  #define REG_ARG_7                REG_R7
+  #define REG_ARG_0                REG_R2
+  #define REG_ARG_1                REG_R3
+  #define REG_ARG_2                REG_R4
+  #define REG_ARG_3                REG_R5
+  #define REG_ARG_4                REG_R6
 
   extern const regNumber intArgRegs [MAX_REG_ARG];
   extern const regMaskTP intArgMasks[MAX_REG_ARG];
 
-  #define RBM_ARG_0                RBM_R0
-  #define RBM_ARG_1                RBM_R1
-  #define RBM_ARG_2                RBM_R2
-  #define RBM_ARG_3                RBM_R3
-  #define RBM_ARG_4                RBM_R4
-  #define RBM_ARG_5                RBM_R5
-  #define RBM_ARG_6                RBM_R6
-  #define RBM_ARG_7                RBM_R7
+  #define RBM_ARG_0                RBM_R2
+  #define RBM_ARG_1                RBM_R3
+  #define RBM_ARG_2                RBM_R4
+  #define RBM_ARG_3                RBM_R5
+  #define RBM_ARG_4                RBM_R6
 
   #define REG_FLTARG_0             REG_V0
   #define REG_FLTARG_1             REG_V1
@@ -315,7 +309,7 @@
   #define RBM_FLTARG_6             RBM_V6
   #define RBM_FLTARG_7             RBM_V7
 
-  #define RBM_ARG_REGS            (RBM_ARG_0|RBM_ARG_1|RBM_ARG_2|RBM_ARG_3|RBM_ARG_4|RBM_ARG_5|RBM_ARG_6|RBM_ARG_7)
+  #define RBM_ARG_REGS            (RBM_ARG_0|RBM_ARG_1|RBM_ARG_2|RBM_ARG_3|RBM_ARG_4)
   #define RBM_FLTARG_REGS         (RBM_FLTARG_0|RBM_FLTARG_1|RBM_FLTARG_2|RBM_FLTARG_3|RBM_FLTARG_4|RBM_FLTARG_5|RBM_FLTARG_6|RBM_FLTARG_7)
 
   extern const regNumber fltArgRegs [MAX_FLOAT_REG_ARG];

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12452,16 +12452,14 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
     const char* ftnName = ftnDesc->GetName();
 
     forceInterpreter = true;
-    if (!strcmp(ftnName, "foo"))
+    if (!strcmp(ftnName, "foo") ||
+        !strcmp(ftnName, "s390xHw") ||
+        !strcmp(ftnName, "oneArg") ||
+        !strcmp(ftnName, "twoArgs") ||
+        !strcmp(ftnName, "addTwo"))
     {
-        printf ("Function name is %s\n", ftnName);
-	interpreterFallback = true;
-    }
-
-    else if (!strcmp(ftnName, "s390xHw"))
-    {
-        printf ("Function name is %s\n", ftnName);
-	interpreterFallback = true;
+        printf("Function name is %s\n", ftnName);
+        interpreterFallback = true;
     }
     else
 	interpreterFallback = false;

--- a/src/s390tests/tests/call_args_int_1.cs
+++ b/src/s390tests/tests/call_args_int_1.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int oneArg(int x) => x + 1;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int s390xHw() => oneArg(10);
+
+    static int Main() => s390xHw() == 11 ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_int_2.cs
+++ b/src/s390tests/tests/call_args_int_2.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int addTwo(int a, int b) => a + b;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int s390xHw() => addTwo(11, 22);
+
+    static int Main() => s390xHw() == 33 ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_int_5.cs
+++ b/src/s390tests/tests/call_args_int_5.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int oneArg(int a, int b, int c, int d, int e) => a + b + c + d + e;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int s390xHw() => oneArg(1, 2, 3, 4, 5);
+
+    static int Main() => s390xHw() == 15 ? 0 : 1;
+}


### PR DESCRIPTION
Align s390x integer argument register mapping with ABI by switching register args from r0-r7 to r2-r6.
Update s390x target arg-register definitions and masks in targets390x.h and targets390x.cpp to reflect 5 integer register arguments.
