### PR TITLE
align s390x FP arg-register mapping and add float/double call tests

### DIFF
--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -3026,7 +3026,7 @@ void CodeGen::genCall(GenTreeCall* call)
     {
         // User function calls kill all caller-saved registers
         // caller-saved: r0-r5, r14, f0-f7
-        killMask = RBM_INT_CALLEE_TRASH | RBM_R14 | RBM_FLT_CALLEE_TRASH;
+        killMask = RBM_CALLEE_TRASH | RBM_R14;
     }
 
     if (callType == CT_INDIRECT)

--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -2972,7 +2972,7 @@ void CodeGen::genCall(GenTreeCall* call)
     regMaskTP argRegsUsed = RBM_NONE;
 
     // Process each argument in the call
-    for (CallArg& arg : call->gtArgs.Args())
+    for (CallArg& arg : call->gtArgs.LateArgs())
     {
         GenTree* argNode = arg.GetNode();
 
@@ -3026,8 +3026,7 @@ void CodeGen::genCall(GenTreeCall* call)
     {
         // User function calls kill all caller-saved registers
         // caller-saved: r0-r5, r14, f0-f7
-        killMask = RBM_R0 | RBM_R1 | RBM_R2 | RBM_R3 | RBM_R4 | RBM_R5 | RBM_R14 |
-                   RBM_F0 | RBM_F1 | RBM_F2 | RBM_F3 | RBM_F4 | RBM_F5 | RBM_F6 | RBM_F7;
+        killMask = RBM_INT_CALLEE_TRASH | RBM_R14 | RBM_FLT_CALLEE_TRASH;
     }
 
     if (callType == CT_INDIRECT)
@@ -3092,7 +3091,7 @@ void CodeGen::genCall(GenTreeCall* call)
 
         if (varTypeIsFloating(returnType))
         {
-            returnReg = REG_F0;
+            returnReg = REG_V0;
         }
         else
         {
@@ -3992,40 +3991,39 @@ const CodeGen::GenConditionDesc CodeGen::GenConditionDesc::map[32]
 {
     { },       // NONE
     { },       // 1
-    { EJ_lt}, // SLT
+    { EJ_lt }, // SLT
     { EJ_le }, // SLE
-    { EJ_ge}, // SGE
+    { EJ_ge }, // SGE
     { EJ_gt }, // SGT
-    { }, // S
-    { }, // NS
+    { },       // S
+    { },       // NS
 
     { EJ_eq }, // EQ
     { EJ_ne }, // NE
-    { }, // ULT
-    { }, // ULE
-    { }, // UGE
-    { }, // UGT
-    { }, // C
-    { }, // NC
-#if 0
-    { EJ_eq },                // FEQ
-    { EJ_gt, GT_AND, EJ_lo }, // FNE
-    { EJ_lo },                // FLT
-    { EJ_ls },                // FLE
-    { EJ_ge },                // FGE
-    { EJ_gt },                // FGT
-    { EJ_vs },                // O
-    { EJ_vc },                // NO
+    { EJ_lt }, // ULT
+    { EJ_le }, // ULE
+    { EJ_ge }, // UGE
+    { EJ_gt }, // UGT
+    { },       // C
+    { },       // NC
 
-    { EJ_eq, GT_OR, EJ_vs },  // FEQU
-    { EJ_ne },                // FNEU
-    { EJ_lt },                // FLTU
-    { EJ_le },                // FLEU
-    { EJ_hs },                // FGEU
-    { EJ_hi },                // FGTU
-    { },                      // P
-    { },                      // NP
-#endif
+    { EJ_eq }, // FEQ
+    { EJ_ne }, // FNE
+    { EJ_lt }, // FLT
+    { EJ_le }, // FLE
+    { EJ_ge }, // FGE
+    { EJ_gt }, // FGT
+    { },       // O
+    { },       // NO
+
+    { EJ_eq }, // FEQU
+    { EJ_ne }, // FNEU
+    { EJ_lt }, // FLTU
+    { EJ_le }, // FLEU
+    { EJ_ge }, // FGEU
+    { EJ_gt }, // FGTU
+    { },       // P
+    { },       // NP
 };
 // clang-format on
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3603,6 +3603,17 @@ inline unsigned genMapFloatRegNumToRegArgNum(regNumber regNum)
     return regNum - REG_V0;
 #elif defined(UNIX_AMD64_ABI)
     return regNum - REG_FLTARG_0;
+#elif defined(TARGET_S390X)
+    switch (regNum)
+    {
+        case REG_FLTARG_0: return 0;  
+        case REG_FLTARG_1: return 1;
+        case REG_FLTARG_2: return 2;
+        case REG_FLTARG_3: return 3;
+        default:
+            assert(!"invalid s390x float arg register");
+            return BAD_VAR_NUM;
+    }
 #else
 
 #if MAX_FLOAT_REG_ARG >= 1

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1249,6 +1249,27 @@ protected:
                 case INS_oihf:
                 case INS_oilf:
                 case INS_xilf:
+                case INS_wfasb:
+                case INS_wfadb:
+                case INS_wfssb:
+                case INS_wfsdb:
+                case INS_wfmsb:
+                case INS_wfmdb:
+                case INS_wfdsb:
+                case INS_wfddb:
+                case INS_wfsqsb:
+                case INS_wfsqdb:
+                case INS_wfcsb:
+                case INS_wfcdb:
+                case INS_wflcsb:
+                case INS_wflcdb:
+                case INS_vlr:
+                case INS_vleg:
+                case INS_vlef:
+                case INS_vsteg:
+                case INS_vstef:
+                case INS_vlgvg:
+                case INS_vlvgg:
                     size = 6;
                     break;
                 default:

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -4535,6 +4535,9 @@ void emitter::emitIns_R_R(instruction     ins,
             case INS_lcebr: ins = INS_wflcsb; break;
             case INS_lcdbr: ins = INS_wflcdb; break;
             case INS_ldgr:  ins = INS_vlvgg;  break;
+            case INS_sqebr: ins = INS_wfsqsb; break;
+            case INS_sqdbr: ins = INS_wfsqdb; break;
+            case INS_lgdr:  ins = INS_vlgvg;  break;
             default: break;
         }
     }
@@ -10481,6 +10484,25 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             S390_VRR_a(dst, op, v1, v2, 0, 8, 3, rxb);
             break;
         }
+
+        case INS_wfsqsb:
+        {
+            op = emitInsCode(ins, fmt);
+            uint8_t v1 = (id->idReg1() - REG_V0) & 0xf;
+            uint8_t v2 = (id->idReg2() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(id->idReg1(), id->idReg2());
+            S390_VRR_a(dst, op, v1, v2, 0, 0, 2, rxb);
+            break;
+        }
+        case INS_wfsqdb:
+        {
+            op = emitInsCode(ins, fmt);
+            uint8_t v1 = (id->idReg1() - REG_V0) & 0xf;
+            uint8_t v2 = (id->idReg2() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(id->idReg1(), id->idReg2());
+            S390_VRR_a(dst, op, v1, v2, 0, 0, 3, rxb);
+            break;
+        }
         
         case INS_vlvgg:
         {
@@ -10488,6 +10510,16 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
             uint8_t rxb = calcRXB(id->idReg1());
             S390_VRS_b(dst, op, v1, id->idReg2(), 0, 0, 0, rxb);
+            break;
+        }
+
+        case INS_vlgvg:
+        {
+            op = emitInsCode(ins, fmt);
+            uint8_t r1 = id->idReg1();
+            uint8_t v3 = (id->idReg2() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(REG_V0, REG_V0, id->idReg2());
+            S390_VRS_c(dst, op, r1, v3, 0, 0, 3, rxb);
             break;
         }
         

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -10451,7 +10451,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
             unsigned v2 = (id->idReg2() - REG_V0) & 0xf;
             uint8_t rxb = calcRXB(id->idReg1(), id->idReg2());
-            S390_VRR_a(dst, op, v1, v2, 0, 2, 0, rxb);
+            S390_VRR_a(dst, op, v1, v2, 0, 0, 2, rxb);
             break;
         }
         
@@ -10461,7 +10461,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
             unsigned v2 = (id->idReg2() - REG_V0) & 0xf;
             uint8_t rxb = calcRXB(id->idReg1(), id->idReg2());
-            S390_VRR_a(dst, op, v1, v2, 0, 3, 0, rxb);
+            S390_VRR_a(dst, op, v1, v2, 0, 0, 3, rxb);
             break;
         }
         
@@ -10509,7 +10509,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             op = emitInsCode(ins, fmt);
             unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
             uint8_t rxb = calcRXB(id->idReg1());
-            S390_VRS_b(dst, op, v1, id->idReg2(), 0, 0, 0, rxb);
+            S390_VRS_b(dst, op, v1, id->idReg2(), 0, 0, 3, rxb);
             break;
         }
 

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -3871,6 +3871,7 @@ void emitter::emitIns_R_R(instruction     ins,
         case INS_lghr:
         case INS_lgr:
         case INS_lr:
+        case INS_vlr:
             fmt = IF_DR_2E;
             break;
 
@@ -4517,6 +4518,26 @@ void emitter::emitIns_R_R(instruction     ins,
 #endif
     } // end switch (ins)
 
+    if (needsVectorEncoding(reg1, reg2))
+    {
+        switch (ins)
+        {
+            case INS_aebr:  ins = INS_wfasb;  break;
+            case INS_adbr:  ins = INS_wfadb;  break;
+            case INS_sebr:  ins = INS_wfssb;  break;
+            case INS_sdbr:  ins = INS_wfsdb;  break;
+            case INS_meebr: ins = INS_wfmsb;  break;
+            case INS_mdbr:  ins = INS_wfmdb;  break;
+            case INS_debr:  ins = INS_wfdsb;  break;
+            case INS_ddbr:  ins = INS_wfddb;  break;
+            case INS_cebr:  ins = INS_wfcsb;  break;
+            case INS_cdbr:  ins = INS_wfcdb;  break;
+            case INS_lcebr: ins = INS_wflcsb; break;
+            case INS_lcdbr: ins = INS_wflcdb; break;
+            case INS_ldgr:  ins = INS_vlvgg;  break;
+            default: break;
+        }
+    }
 
     instrDesc* id = emitNewInstrSmall(attr);
 
@@ -5356,6 +5377,17 @@ void emitter::emitIns_R_R_I(instruction     ins,
     }
 #endif
 
+    if (isHighVectorRegister(reg1))
+    {
+        switch (ins)
+        {
+            case INS_ley:  ins = INS_vlef;  break;
+            case INS_ldy:  ins = INS_vleg;  break;
+            case INS_stey: ins = INS_vstef; break;
+            case INS_stdy: ins = INS_vsteg; break;
+            default: break;
+        }
+    }
 
     instrDesc* id = emitNewInstrSC(attr, imm);
 
@@ -7572,6 +7604,19 @@ void emitter::emitIns_R_S(instruction ins, emitAttr attr, regNumber reg1, int va
         return;
     }
 #endif
+
+    if (isHighVectorRegister(reg1))
+    {
+        switch (ins)
+        {
+            case INS_ley:  ins = INS_vlef;  break;
+            case INS_ldy:  ins = INS_vleg;  break;
+            case INS_stey: ins = INS_vstef; break;
+            case INS_stdy: ins = INS_vsteg; break;
+            default: break;
+        }
+    }
+
     instrDesc* id = emitNewInstrCns(attr, imm);
 
     id->idIns(ins);
@@ -7811,6 +7856,19 @@ void emitter::emitIns_S_R(instruction ins, emitAttr attr, regNumber reg1, int va
         return;
     }
 #endif
+
+    if (isHighVectorRegister(reg1))
+    {
+        switch (ins)
+        {
+            case INS_ley:  ins = INS_vlef;  break;
+            case INS_ldy:  ins = INS_vleg;  break;
+            case INS_stey: ins = INS_vstef; break;
+            case INS_stdy: ins = INS_vsteg; break;
+            default: break;
+        }
+    }
+
     instrDesc* id = emitNewInstrCns(attr, imm);
 
     id->idIns(ins);
@@ -10117,19 +10175,29 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_ley:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-            S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
+            S390_RXY_a(dst, op, (id->idReg1() - REG_V0), 0, id->idReg2(), imm);
             break;
-
+        
         case INS_ldy:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-            S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
+            S390_RXY_a(dst, op, (id->idReg1() - REG_V0), 0, id->idReg2(), imm);
             break;
 
         case INS_lgr:
             op = emitInsCode(ins, fmt);
             S390_RRE(dst, op, id->idReg1(), id->idReg2());
             break;
+
+        case INS_vlr:
+        {
+            op = emitInsCode(INS_vlr, fmt);
+            unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
+            unsigned v2 = (id->idReg2() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(id->idReg1(), id->idReg2());
+            S390_VRR_a(dst, op, v1, v2, 0, 0, 0, rxb);
+            break;
+        }
 
         case INS_lgfi:
             imm = emitGetInsSC(id);
@@ -10271,119 +10339,227 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
         case INS_aebr:
             op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
             break;
-
-	case INS_cebr:
-            op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
-            break;
-
-	case INS_cdbr:
-            op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
-            break;
-
+        
         case INS_adbr:
             op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
             break;
-
-        case INS_ldgr:
-            op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2());
-            break;
-
+        
         case INS_sebr:
             op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
             break;
-
+        
         case INS_sdbr:
             op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
             break;
-
+        
         case INS_meebr:
             op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
             break;
-
+        
         case INS_mdbr:
             op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
             break;
-
+        
         case INS_debr:
             op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
             break;
-
+        
         case INS_ddbr:
             op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
+            break;
+        
+        case INS_cebr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
+            break;
+        
+        case INS_cdbr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
+            break;
+        
+        case INS_lcebr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
+            break;
+        
+        case INS_lcdbr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
+            break;
+        
+        case INS_ldgr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), id->idReg2());
             break;
 
         case INS_stey:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-            S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
+            S390_RXY_a(dst, op, (id->idReg1() - REG_V0), 0, id->idReg2(), imm);
             break;
-
+        
         case INS_stdy:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-            S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
+            S390_RXY_a(dst, op, (id->idReg1() - REG_V0), 0, id->idReg2(), imm);
             break;
 
+        case INS_wfasb:
+        case INS_wfssb:
+        case INS_wfmsb:
+        case INS_wfdsb:
+        {
+            op = emitInsCode(ins, fmt);
+            unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
+            unsigned v2 = (id->idReg1() - REG_V0) & 0xf;
+            unsigned v3 = (id->idReg2() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(id->idReg1(), id->idReg1(), id->idReg2());
+            S390_VRR_c(dst, op, v1, v2, v3, 0, 8, 2, rxb);
+            break;
+        }
+        
+        case INS_wfadb:
+        case INS_wfsdb:
+        case INS_wfmdb:
+        case INS_wfddb:
+        {
+            op = emitInsCode(ins, fmt);
+            unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
+            unsigned v2 = (id->idReg1() - REG_V0) & 0xf;
+            unsigned v3 = (id->idReg2() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(id->idReg1(), id->idReg1(), id->idReg2());
+            S390_VRR_c(dst, op, v1, v2, v3, 0, 8, 3, rxb);
+            break;
+        }
+        
+        case INS_wfcsb:
+        {
+            op = emitInsCode(ins, fmt);
+            unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
+            unsigned v2 = (id->idReg2() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(id->idReg1(), id->idReg2());
+            S390_VRR_a(dst, op, v1, v2, 0, 2, 0, rxb);
+            break;
+        }
+        
+        case INS_wfcdb:
+        {
+            op = emitInsCode(ins, fmt);
+            unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
+            unsigned v2 = (id->idReg2() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(id->idReg1(), id->idReg2());
+            S390_VRR_a(dst, op, v1, v2, 0, 3, 0, rxb);
+            break;
+        }
+        
+        case INS_wflcsb:
+        {
+            op = emitInsCode(ins, fmt);
+            unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
+            unsigned v2 = (id->idReg2() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(id->idReg1(), id->idReg2());
+            S390_VRR_a(dst, op, v1, v2, 0, 8, 2, rxb);
+            break;
+        }
+        
+        case INS_wflcdb:
+        {
+            op = emitInsCode(ins, fmt);
+            unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
+            unsigned v2 = (id->idReg2() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(id->idReg1(), id->idReg2());
+            S390_VRR_a(dst, op, v1, v2, 0, 8, 3, rxb);
+            break;
+        }
+        
+        case INS_vlvgg:
+        {
+            op = emitInsCode(ins, fmt);
+            unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(id->idReg1());
+            S390_VRS_b(dst, op, v1, id->idReg2(), 0, 0, 0, rxb);
+            break;
+        }
+        
+        case INS_vlef:
+        case INS_vstef:
+        {
+            op = emitInsCode(ins, fmt);
+            imm = emitGetInsSC(id);
+            unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(id->idReg1());
+            S390_VRX(dst, op, v1, 0, id->idReg2(), imm, 0, rxb);
+            break;
+        }
+        
+        case INS_vleg:
+        case INS_vsteg:
+        {
+            op = emitInsCode(ins, fmt);
+            imm = emitGetInsSC(id);
+            unsigned v1 = (id->idReg1() - REG_V0) & 0xf;
+            uint8_t rxb = calcRXB(id->idReg1());
+            S390_VRX(dst, op, v1, 0, id->idReg2(), imm, 0, rxb);
+            break;
+        }
         case INS_cfebr:
             op = emitInsCode(ins, fmt);
-            S390_RRF_2(dst, op, id->idReg1(), 5, id->idReg2());
+            S390_RRF_2(dst, op, id->idReg1(), 5, id->idReg2() - REG_V0);
             break;
 
         case INS_cfdbr:
             op = emitInsCode(ins, fmt);
-            S390_RRF_2(dst, op, id->idReg1(), 5, id->idReg2());
+            S390_RRF_2(dst, op, id->idReg1(), 5, id->idReg2() - REG_V0);
             break;
 
         case INS_cgebr:
             op = emitInsCode(ins, fmt);
-            S390_RRF_2(dst, op, id->idReg1(), 5, id->idReg2());
+            S390_RRF_2(dst, op, id->idReg1(), 5, id->idReg2() - REG_V0);
             break;
 
         case INS_cgdbr:
             op = emitInsCode(ins, fmt);
-            S390_RRF_2(dst, op, id->idReg1(), 5, id->idReg2());
+            S390_RRF_2(dst, op, id->idReg1(), 5, id->idReg2() - REG_V0);
             break;
 
         case INS_clfebr:
             op = emitInsCode(ins, fmt);
-            S390_RRF_4(dst, op, id->idReg1(), 5, id->idReg2(), 0);
+            S390_RRF_4(dst, op, id->idReg1(), 5, id->idReg2() - REG_V0, 0);
             break;
 
         case INS_clfdbr:
             op = emitInsCode(ins, fmt);
-            S390_RRF_4(dst, op, id->idReg1(), 5, id->idReg2(), 0);
+            S390_RRF_4(dst, op, id->idReg1(), 5, id->idReg2() - REG_V0, 0);
             break;
 
         case INS_clgebr:
             op = emitInsCode(ins, fmt);
-            S390_RRF_4(dst, op, id->idReg1(), 5, id->idReg2(), 0);
+            S390_RRF_4(dst, op, id->idReg1(), 5, id->idReg2() - REG_V0, 0);
             break;
 
         case INS_clgdbr:
             op = emitInsCode(ins, fmt);
-            S390_RRF_4(dst, op, id->idReg1(), 5, id->idReg2(), 0);
-            break;
-
-        case INS_ledbr:
-            op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
+            S390_RRF_4(dst, op, id->idReg1(), 5, id->idReg2() - REG_V0, 0);
             break;
 
         case INS_ldebr:
             op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1() - 16, id->idReg2() - 16);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
+            break;
+
+        case INS_ledbr:
+            op = emitInsCode(ins, fmt);
+            S390_RRE(dst, op, (id->idReg1() - REG_V0), (id->idReg2() - REG_V0));
             break;
 
         case INS_afi:
@@ -10514,8 +10690,6 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             S390_RR(dst, op, id->idReg1(), id->idReg2());
             break;
 
-        case INS_lcdbr:
-        case INS_lcebr:
         case INS_lcgr:
             op = emitInsCode(ins, fmt);
             S390_RRE(dst, op, id->idReg1(), id->idReg2());

--- a/src/coreclr/jit/emits390x.h
+++ b/src/coreclr/jit/emits390x.h
@@ -99,16 +99,18 @@ static bool strictArmAsm;
 #define S390_VRR_c(dst, opc, v1, v2, v3, m6, m5, m4, rxb)              \
 {                                                                       \
     dst += emitOutputWord(dst, (((opc >> 8) << 8) | ((v1 & 0xf) << 4) | (v2 & 0xf))); \
-    dst += emitOutputLong(dst, (((v3 & 0xf) << 28) | ((m6) << 24) |    \
-                          ((m5) << 20) | ((m4) << 16) |                 \
-                          ((rxb) << 8) | (opc & 0xff)));                \
+    dst += emitOutputLong(dst, (((v3 & 0xf) << 28) |                   \
+                          ((m6 & 0xf) << 20) | ((m5 & 0xf) << 16) |    \
+                          ((m4 & 0xf) << 12) | ((rxb & 0xf) << 8) |    \
+                          (opc & 0xff)));                               \
 }
 
-#define S390_VRR_a(dst, opc, v1, v2, m5, m4, m3, rxb)                  \
+#define S390_VRR_a(dst, opc, v1, v2, m4, m5, m3, rxb)                  \
 {                                                                       \
     dst += emitOutputWord(dst, (((opc >> 8) << 8) | ((v1 & 0xf) << 4) | (v2 & 0xf))); \
-    dst += emitOutputLong(dst, (((m5) << 24) | ((m4) << 20) |          \
-                          ((m3) << 16) | ((rxb) << 8) | (opc & 0xff))); \
+    dst += emitOutputLong(dst, (((m4 & 0xf) << 20) | ((m5 & 0xf) << 16) |  \
+                          ((m3 & 0xf) << 12) | ((rxb & 0xf) << 8) |    \
+                          (opc & 0xff)));                               \
 }
 
 #define S390_VRX(dst, opc, v1, x2, b2, d2, m3, rxb)                    \

--- a/src/coreclr/jit/emits390x.h
+++ b/src/coreclr/jit/emits390x.h
@@ -96,11 +96,6 @@ static bool strictArmAsm;
     dst += emitOutputLong(dst, ((opc << 24) | ((r1) << 20) |((r3) << 16) | ((b2) << 12) | ((d2) & 0xfff)));    \
 }
 
-#define S390_NOP2(dst)                                                  \
-{                                                                       \
-    dst += emitOutputWord(dst, 0x0700);                                 \
-}
-
 #define S390_VRR_c(dst, opc, v1, v2, v3, m6, m5, m4, rxb)              \
 {                                                                       \
     dst += emitOutputWord(dst, (((opc >> 8) << 8) | ((v1 & 0xf) << 4) | (v2 & 0xf))); \

--- a/src/coreclr/jit/emits390x.h
+++ b/src/coreclr/jit/emits390x.h
@@ -96,6 +96,47 @@ static bool strictArmAsm;
     dst += emitOutputLong(dst, ((opc << 24) | ((r1) << 20) |((r3) << 16) | ((b2) << 12) | ((d2) & 0xfff)));    \
 }
 
+#define S390_NOP2(dst)                                                  \
+{                                                                       \
+    dst += emitOutputWord(dst, 0x0700);                                 \
+}
+
+#define S390_VRR_c(dst, opc, v1, v2, v3, m6, m5, m4, rxb)              \
+{                                                                       \
+    dst += emitOutputWord(dst, (((opc >> 8) << 8) | ((v1 & 0xf) << 4) | (v2 & 0xf))); \
+    dst += emitOutputLong(dst, (((v3 & 0xf) << 28) | ((m6) << 24) |    \
+                          ((m5) << 20) | ((m4) << 16) |                 \
+                          ((rxb) << 8) | (opc & 0xff)));                \
+}
+
+#define S390_VRR_a(dst, opc, v1, v2, m5, m4, m3, rxb)                  \
+{                                                                       \
+    dst += emitOutputWord(dst, (((opc >> 8) << 8) | ((v1 & 0xf) << 4) | (v2 & 0xf))); \
+    dst += emitOutputLong(dst, (((m5) << 24) | ((m4) << 20) |          \
+                          ((m3) << 16) | ((rxb) << 8) | (opc & 0xff))); \
+}
+
+#define S390_VRX(dst, opc, v1, x2, b2, d2, m3, rxb)                    \
+{                                                                       \
+    dst += emitOutputWord(dst, (((opc >> 8) << 8) | ((v1 & 0xf) << 4) | (x2 & 0xf))); \
+    dst += emitOutputLong(dst, (((b2 & 0xf) << 28) | (((d2) & 0xfff) << 16) | \
+                          ((m3) << 12) | ((rxb) << 8) | (opc & 0xff))); \
+}
+
+#define S390_VRS_b(dst, opc, v1, r3, b2, d2, m4, rxb)                  \
+{                                                                       \
+    dst += emitOutputWord(dst, (((opc >> 8) << 8) | ((v1 & 0xf) << 4) | (r3 & 0xf))); \
+    dst += emitOutputLong(dst, (((b2 & 0xf) << 28) | (((d2) & 0xfff) << 16) | \
+                          ((m4) << 12) | ((rxb) << 8) | (opc & 0xff))); \
+}
+
+#define S390_VRS_c(dst, opc, r1, v3, b2, d2, m4, rxb)                  \
+{                                                                       \
+    dst += emitOutputWord(dst, (((opc >> 8) << 8) | ((r1 & 0xf) << 4) | (v3 & 0xf))); \
+    dst += emitOutputLong(dst, (((b2 & 0xf) << 28) | (((d2) & 0xfff) << 16) | \
+                          ((m4) << 12) | ((rxb) << 8) | (opc & 0xff))); \
+}
+
 /************************************************************************/
 /*         Routines that compute the size of / encode instructions      */
 /************************************************************************/
@@ -1225,6 +1266,27 @@ inline static bool isLowVectorRegister(regNumber reg)
 inline static bool isFloatReg(regNumber reg)
 {
     return isVectorRegister(reg);
+}
+
+inline static bool isHighVectorRegister(regNumber reg)
+{
+    return (reg >= REG_V16 && reg <= REG_V31);
+}
+
+inline static bool needsVectorEncoding(regNumber reg1, regNumber reg2)
+{
+    return isHighVectorRegister(reg1) || isHighVectorRegister(reg2);
+}
+
+static uint8_t calcRXB(regNumber v1, regNumber v2 = REG_V0,
+                       regNumber v3 = REG_V0, regNumber v4 = REG_V0)
+{
+    uint8_t rxb = 0;
+    if (((unsigned)v1 - (unsigned)REG_V0) >= 16) rxb |= 0x08;
+    if (((unsigned)v2 - (unsigned)REG_V0) >= 16) rxb |= 0x04;
+    if (((unsigned)v3 - (unsigned)REG_V0) >= 16) rxb |= 0x02;
+    if (((unsigned)v4 - (unsigned)REG_V0) >= 16) rxb |= 0x01;
+    return rxb;
 }
 
 

--- a/src/coreclr/jit/instrss390x.h
+++ b/src/coreclr/jit/instrss390x.h
@@ -253,6 +253,29 @@ INST(ble,           "brcl",           0,    0xC04)
 INST(blt,           "brcl",           0,    0xC04)
 INST(bge,           "brcl",           0,    0xC04)
 
+//// Vector FP (VRR/VRX, 6 bytes) — used for V16-V31 in hybrid approach
+INST(wfasb,     "wfasb",        0,      0xe7e3)
+INST(wfadb,     "wfadb",        0,      0xe7e3)
+INST(wfssb,     "wfssb",        0,      0xe7e2)
+INST(wfsdb,     "wfsdb",        0,      0xe7e2)
+INST(wfmsb,     "wfmsb",        0,      0xe7e7)
+INST(wfmdb,     "wfmdb",        0,      0xe7e7)
+INST(wfdsb,     "wfdsb",        0,      0xe7e5)
+INST(wfddb,     "wfddb",        0,      0xe7e5)
+INST(wfsqsb,    "wfsqsb",       0,      0xe7ce)
+INST(wfsqdb,    "wfsqdb",       0,      0xe7ce)
+INST(wfcsb,     "wfcsb",        0,      0xe7cb)
+INST(wfcdb,     "wfcdb",        0,      0xe7cb)
+INST(wflcsb,    "wflcsb",       0,      0xe7cc)
+INST(wflcdb,    "wflcdb",       0,      0xe7cc)
+INST(vlr,       "vlr",          0,      0xe756)
+INST(vleg,      "vleg",         0,      0xe702)
+INST(vlef,      "vlef",         0,      0xe703)
+INST(vsteg,     "vsteg",        0,      0xe70a)
+INST(vstef,     "vstef",        0,      0xe70b)
+INST(vlgvg,     "vlgvg",        0,      0xe721)
+INST(vlvgg,     "vlvgg",        0,      0xe722)
+
 // clang-format on
 /*****************************************************************************/
 #undef INST

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -545,7 +545,7 @@ static const regMaskTP LsraLimitSmallIntSet = (RBM_R0 | RBM_R1 | RBM_R2 | RBM_R1
 static const regMaskTP LsraLimitSmallFPSet  = (RBM_V0 | RBM_V1 | RBM_V2 | RBM_V8 | RBM_V9);
 #elif defined(TARGET_S390X)
 static const regMaskTP LsraLimitSmallIntSet = (RBM_R0 | RBM_R1 | RBM_R7 | RBM_R8 | RBM_R9);
-static const regMaskTP LsraLimitSmallFPSet  = (RBM_F1 | RBM_F3 | RBM_F8 | RBM_F9 | RBM_F10);
+static const regMaskTP LsraLimitSmallFPSet  = (RBM_V1 | RBM_V3 | RBM_V8 | RBM_V9 | RBM_V10);
 #elif defined(TARGET_X86)
 static const regMaskTP LsraLimitSmallIntSet = (RBM_EAX | RBM_ECX | RBM_EDI);
 static const regMaskTP LsraLimitSmallFPSet  = (RBM_XMM0 | RBM_XMM1 | RBM_XMM2 | RBM_XMM6 | RBM_XMM7);

--- a/src/coreclr/jit/registers390x.h
+++ b/src/coreclr/jit/registers390x.h
@@ -38,30 +38,7 @@ REGALIAS(R11, FP)
 REGALIAS(R14, LR)
 REGALIAS(R15, SP)
 
-
-#define FBASE 16 
-#define FMASK(x) (1ULL << (FBASE+(x)))
-
-/*
-REGDEF(name,  rnum,       mask,  xname,  wname) */
-REGDEF(F0,    0+FBASE, FMASK(0),  "f0")
-REGDEF(F1,    1+FBASE, FMASK(1),  "f1")
-REGDEF(F2,    2+FBASE, FMASK(2),  "f2")
-REGDEF(F3,    3+FBASE, FMASK(3),  "f3")
-REGDEF(F4,    4+FBASE, FMASK(4),  "f4")
-REGDEF(F5,    5+FBASE, FMASK(5),  "f5")
-REGDEF(F6,    6+FBASE, FMASK(6),  "f6")
-REGDEF(F7,    7+FBASE, FMASK(7),  "f7")
-REGDEF(F8,    8+FBASE, FMASK(8),  "f8")
-REGDEF(F9,    9+FBASE, FMASK(9),  "f9")
-REGDEF(F10,  10+FBASE, FMASK(10), "f10")
-REGDEF(F11,  11+FBASE, FMASK(11), "f11")
-REGDEF(F12,  12+FBASE, FMASK(12), "f12")
-REGDEF(F13,  13+FBASE, FMASK(13), "f13")
-REGDEF(F14,  14+FBASE, FMASK(14), "f14")
-REGDEF(F15,  15+FBASE, FMASK(15), "f15")
-
-#define VBASE 32 
+#define VBASE 16
 #define VMASK(x) (1ULL << (VBASE+(x)))
 
 REGDEF(V0,    0+VBASE, VMASK(0),  "v0")
@@ -97,9 +74,10 @@ REGDEF(V29,  29+VBASE, VMASK(29), "v29")
 REGDEF(V30,  30+VBASE, VMASK(30), "v30")
 REGDEF(V31,  31+VBASE, VMASK(31), "v31")
 
+// F registers are aliases for V0-V15 (FPR0-15 = low 64 bits of VR0-15)
 
-// The registers with values 80 (NBASE) and above are not real register numbers
-#define NBASE 64
+// The registers with values 48 (NBASE) and above are not real register numbers
+#define NBASE 48
 
 REGDEF(FPC,    0+NBASE, 0x0000,    "fpc")
 // This must be last!

--- a/src/coreclr/jit/targets390x.cpp
+++ b/src/coreclr/jit/targets390x.cpp
@@ -20,8 +20,8 @@ const Target::ArgOrder Target::g_tgtUnmanagedArgOrder = ARG_ORDER_R2L;
 const regNumber intArgRegs [] = {REG_R2, REG_R3, REG_R4, REG_R5, REG_R6};
 const regMaskTP intArgMasks[] = {RBM_R2, RBM_R3, RBM_R4, RBM_R5, RBM_R6};
 
-const regNumber fltArgRegs [] = {REG_V0, REG_V1, REG_V2, REG_V3, REG_V4, REG_V5, REG_V6, REG_V7 };
-const regMaskTP fltArgMasks[] = {RBM_V0, RBM_V1, RBM_V2, RBM_V3, RBM_V4, RBM_V5, RBM_V6, RBM_V7 };
+const regNumber fltArgRegs [] = {REG_V0, REG_V2, REG_V4, REG_V6};
+const regMaskTP fltArgMasks[] = {RBM_V0, RBM_V2, RBM_V4, RBM_V6};
 // clang-format on
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/targets390x.h
+++ b/src/coreclr/jit/targets390x.h
@@ -274,7 +274,7 @@
   #define RET_BUFF_ARGNUM          5
 
   #define MAX_REG_ARG              5
-  #define MAX_FLOAT_REG_ARG        8
+  #define MAX_FLOAT_REG_ARG        4
 
   #define REG_ARG_FIRST            REG_R2
   #define REG_ARG_LAST             REG_R6

--- a/src/coreclr/jit/targets390x.h
+++ b/src/coreclr/jit/targets390x.h
@@ -46,10 +46,10 @@
 
 
 					 //
-  #define REG_FP_FIRST             REG_F0
-  #define REG_FP_LAST              REG_F15
-  #define FIRST_FP_ARGREG          REG_F0
-  #define LAST_FP_ARGREG           REG_F6
+  #define REG_FP_FIRST             REG_V0
+  #define REG_FP_LAST              REG_V31
+  #define FIRST_FP_ARGREG          REG_V0
+  #define LAST_FP_ARGREG           REG_V6
 
   #define REGNUM_BITS              7       // number of bits in a REG_*
   #define REGSIZE_BYTES            8       // number of bytes in one general purpose register
@@ -66,12 +66,14 @@
   #define CODE_ALIGN               2       // code alignment requirement
   #define STACK_ALIGN              8      // stack alignment requirement
 					  
-  #define FIRST_FLT_CALLEE_SAVED  REG_F8
+  #define FIRST_FLT_CALLEE_SAVED  REG_V8
   #define FIRST_INT_CALLEE_SAVED  REG_R6
   #define RBM_INT_CALLEE_SAVED    (RBM_R6|RBM_R7|RBM_R8|RBM_R9|RBM_R10|RBM_R12|RBM_R13)
   #define RBM_INT_CALLEE_TRASH    (RBM_R0|RBM_R1|RBM_R2|RBM_R3|RBM_R4|RBM_R5)
-  #define RBM_FLT_CALLEE_SAVED    (RBM_F8|RBM_F9|RBM_F10|RBM_F11|RBM_F12|RBM_F13|RBM_F14|RBM_F15)
-  #define RBM_FLT_CALLEE_TRASH    (RBM_F0|RBM_F1|RBM_F2|RBM_F3|RBM_F4|RBM_F5|RBM_F6|RBM_F7)
+  #define RBM_FLT_CALLEE_SAVED    (RBM_V8|RBM_V9|RBM_V10|RBM_V11|RBM_V12|RBM_V13|RBM_V14|RBM_V15)
+  #define RBM_FLT_CALLEE_TRASH    (RBM_V0|RBM_V1|RBM_V2|RBM_V3|RBM_V4|RBM_V5|RBM_V6|RBM_V7| \
+                                   RBM_V16|RBM_V17|RBM_V18|RBM_V19|RBM_V20|RBM_V21|RBM_V22|RBM_V23| \
+                                   RBM_V24|RBM_V25|RBM_V26|RBM_V27|RBM_V28|RBM_V29|RBM_V30|RBM_V31)
 
 
   #define RBM_CALLEE_SAVED        (RBM_INT_CALLEE_SAVED | RBM_FLT_CALLEE_SAVED)
@@ -89,8 +91,10 @@
                                    REG_R6, REG_R7, REG_R8, REG_R9, REG_R10,REG_R12,\
                                    REG_R13					   
 
-  #define REG_VAR_ORDER_FLT        REG_F0, REG_F1, REG_F2, REG_F3, REG_F4, REG_F5, REG_F6, REG_F7,   \
-				   REG_F8, REG_F9, REG_F10, REG_F11, REG_F12, REG_F13, REG_F14, REG_F15\
+  #define REG_VAR_ORDER_FLT        REG_V0, REG_V1, REG_V2, REG_V3, REG_V4, REG_V5, REG_V6, REG_V7,   \
+                                   REG_V16, REG_V17, REG_V18, REG_V19, REG_V20, REG_V21, REG_V22, REG_V23, \
+                                   REG_V24, REG_V25, REG_V26, REG_V27, REG_V28, REG_V29, REG_V30, REG_V31, \
+                                   REG_V8, REG_V9, REG_V10, REG_V11, REG_V12, REG_V13, REG_V14, REG_V15
 
   #define RBM_CALL_GC_REGS_ORDER   RBM_R6,RBM_R7,RBM_R8,RBM_R9,RBM_R10,RBM_R12,RBM_R13
   #define RBM_CALL_GC_REGS         (RBM_INT_CALLEE_SAVED|RBM_INTRET|RBM_INTRET_1)
@@ -101,7 +105,7 @@
   #define CNT_CALL_GC_REGS        (7)
 
   #define CNT_CALLEE_SAVED_FLOAT  (8)
-  #define CNT_CALLEE_TRASH_FLOAT  (8)
+  #define CNT_CALLEE_TRASH_FLOAT  (24)
   #define CNT_CALLEE_SAVED_MASK   (0) //s390x doesn't have mask registers,Giri TODO: what should be correct values here ? 
   #define CNT_CALLEE_TRASH_MASK   (0) //s390x doesn't have mask registers,Giri TODO: what should be correct values here ? 
 
@@ -237,9 +241,9 @@
   #define REG_INTRET_1             REG_R3
   #define RBM_INTRET_1             RBM_R3
 
-  #define REG_FLOATRET             REG_F0
-  #define RBM_FLOATRET             RBM_F0
-  #define RBM_DOUBLERET            RBM_F0
+  #define REG_FLOATRET             REG_V0
+  #define RBM_FLOATRET             RBM_V0
+  #define RBM_DOUBLERET            RBM_V0
 
   // The registers trashed by the CORINFO_HELP_STOP_FOR_GC helper
   #define RBM_STOP_FOR_GC_TRASH    RBM_CALLEE_TRASH
@@ -274,8 +278,8 @@
 
   #define REG_ARG_FIRST            REG_R2
   #define REG_ARG_LAST             REG_R6
-  #define REG_ARG_FP_FIRST         REG_F0
-  #define REG_ARG_FP_LAST          REG_F7
+  #define REG_ARG_FP_FIRST         REG_V0
+  #define REG_ARG_FP_LAST          REG_V7
   #define INIT_ARG_STACK_SLOT      0                  // No outgoing reserved stack slots
 
   #define REG_ARG_0                REG_R2
@@ -293,23 +297,23 @@
   #define RBM_ARG_3                RBM_R5
   #define RBM_ARG_4                RBM_R6
 
-  #define REG_FLTARG_0             REG_F0
-  #define REG_FLTARG_1             REG_F1
-  #define REG_FLTARG_2             REG_F2
-  #define REG_FLTARG_3             REG_F3
-  #define REG_FLTARG_4             REG_F4
-  #define REG_FLTARG_5             REG_F5
-  #define REG_FLTARG_6             REG_F6
-  #define REG_FLTARG_7             REG_F7
+  #define REG_FLTARG_0             REG_V0
+  #define REG_FLTARG_1             REG_V1
+  #define REG_FLTARG_2             REG_V2
+  #define REG_FLTARG_3             REG_V3
+  #define REG_FLTARG_4             REG_V4
+  #define REG_FLTARG_5             REG_V5
+  #define REG_FLTARG_6             REG_V6
+  #define REG_FLTARG_7             REG_V7
 
-  #define RBM_FLTARG_0             RBM_F0
-  #define RBM_FLTARG_1             RBM_F1
-  #define RBM_FLTARG_2             RBM_F2
-  #define RBM_FLTARG_3             RBM_F3
-  #define RBM_FLTARG_4             RBM_F4
-  #define RBM_FLTARG_5             RBM_F5
-  #define RBM_FLTARG_6             RBM_F6
-  #define RBM_FLTARG_7             RBM_F7
+  #define RBM_FLTARG_0             RBM_V0
+  #define RBM_FLTARG_1             RBM_V1
+  #define RBM_FLTARG_2             RBM_V2
+  #define RBM_FLTARG_3             RBM_V3
+  #define RBM_FLTARG_4             RBM_V4
+  #define RBM_FLTARG_5             RBM_V5
+  #define RBM_FLTARG_6             RBM_V6
+  #define RBM_FLTARG_7             RBM_V7
 
   #define RBM_ARG_REGS            (RBM_ARG_0|RBM_ARG_1|RBM_ARG_2|RBM_ARG_3|RBM_ARG_4)
   #define RBM_FLTARG_REGS         (RBM_FLTARG_0|RBM_FLTARG_1|RBM_FLTARG_2|RBM_FLTARG_3|RBM_FLTARG_4|RBM_FLTARG_5|RBM_FLTARG_6|RBM_FLTARG_7)

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12405,15 +12405,19 @@ static CorJitResult CompileMethodWithEtwWrapper(EEJitManager *jitMgr,
 //
 // Helper function to check if a function name should use interpreter fallback
 //
-static bool isJitted(MethodDesc* ftnDesc,const char* ftnName)
+static bool isJitted(MethodDesc* ftnDesc, const char* ftnName)
 {
     // List of functions to be jitted and fall back if they fail to jit
     static const char* JittedFunctions[] = {
-	    "foo",
-            "s390xHw",
-            "oneArg",
-            "twoArgs",
-            "addTwo",
+        "foo",
+        "s390xHw",
+        "oneArg",
+        "addOne",
+        "twoArgs",
+        "addTwo",
+        "addFour",
+        "identityBool",
+        "identityChar",
     };
 
     // 2D array for class name and function name combinations to exclude from JIT compilation
@@ -12429,19 +12433,18 @@ static bool isJitted(MethodDesc* ftnDesc,const char* ftnName)
        { "System.Collections.Generic.NonRandomizedStringEqualityComparer", ".ctor"},
        { "System.Collections.Generic.List`1[__Canon]", ".ctor"},
        { "System.Runtime.CompilerServices.QCallTypeHandle", ".ctor"},
-       { "System.Resources.ResourceManager", ".ctor"}, //Assertion failed 'Unhandled TARGET in getReturnTypeForStruct'
+       { "System.Resources.ResourceManager", ".ctor"},
        { "RuntimeTypeCache", ".ctor"},
        { "System.Runtime.CompilerServices.QCallModule", ".ctor"},
        { "System.Runtime.CompilerServices.ObjectHandleOnStack", ".ctor"},
        { "System.Reflection.MetadataImport", ".ctor"},
-       { "System.Runtime.CompilerServices.DefaultInterpolatedStringHandler", ".ctor"}, //Assertion failed 'Unhandled TARGET in getReturnTypeForStruct'
+       { "System.Runtime.CompilerServices.DefaultInterpolatedStringHandler", ".ctor"},
        { "System.Runtime.CompilerServices.ConditionalWeakTable`2[__Canon,__Canon]", ".ctor"},
        { "Container[__Canon,__Canon]", ".ctor"},
     };
 
     const size_t numExclusions = sizeof(jitExclusionList) / sizeof(jitExclusionList[0]);
 
-    // Check if the current class/function combination should be excluded from JIT
     for (size_t i = 0; i < numExclusions; i++)
     {
         if (!strcmp(ftnDesc->m_pszDebugClassName, jitExclusionList[i].className) &&
@@ -12450,7 +12453,7 @@ static bool isJitted(MethodDesc* ftnDesc,const char* ftnName)
             return false;
         }
     }
-    
+
     const size_t numFunctions = sizeof(JittedFunctions) / sizeof(JittedFunctions[0]);
 
     for (size_t i = 0; i < numFunctions; i++)
@@ -12463,7 +12466,7 @@ static bool isJitted(MethodDesc* ftnDesc,const char* ftnName)
 
     return false;
 }
-#endif 
+#endif // TARGET_S390X
 
 //
 // Helper function because can't have dtors in BEGIN_SO_TOLERANT_CODE.
@@ -12516,7 +12519,7 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
     const char* ftnName = ftnDesc->GetName();
 
     forceInterpreter = true;
-    if (isJitted(ftnDesc,ftnName))
+    if (isJitted(ftnDesc, ftnName))
     {
         printf("Jitted Function name is %s\n", ftnName);
         interpreterFallback = true;
@@ -12524,7 +12527,7 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
     else
     {
         printf("Interpreted Function name is %s\n", ftnName);
-	interpreterFallback = false;
+        interpreterFallback = false;
     }
 #endif
 

--- a/src/s390tests/tests/call_args_bool_1.cs
+++ b/src/s390tests/tests/call_args_bool_1.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool identityBool(bool x) => x;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool s390xHw() => identityBool(true);
+
+    static int Main() => s390xHw() == true ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_byte_1.cs
+++ b/src/s390tests/tests/call_args_byte_1.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static byte addOne(byte x) => (byte)(x + 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static byte s390xHw() => addOne(10);
+
+    static int Main() => s390xHw() == 11 ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_char_1.cs
+++ b/src/s390tests/tests/call_args_char_1.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static char identityChar(char x) => x;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static char s390xHw() => identityChar('A');
+
+    static int Main() => s390xHw() == 'A' ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_double_1.cs
+++ b/src/s390tests/tests/call_args_double_1.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static double addOne(double x) => x + 1.0;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static double s390xHw() => addOne(10.0);
+
+    static int Main() => s390xHw() == 11.0 ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_double_2.cs
+++ b/src/s390tests/tests/call_args_double_2.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static double addTwo(double a, double b) => a + b;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static double s390xHw() => addTwo(11.0, 22.0);
+
+    static int Main() => s390xHw() == 33.0 ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_double_4.cs
+++ b/src/s390tests/tests/call_args_double_4.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static double addFour(double a, double b, double c, double d) => a + b + c + d;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static double s390xHw() => addFour(1.0, 2.0, 3.0, 4.0);
+
+    static int Main() => s390xHw() == 10.0 ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_float_1.cs
+++ b/src/s390tests/tests/call_args_float_1.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static float addOne(float x) => x + 1.0f;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static float s390xHw() => addOne(10.0f);
+
+    static int Main() => s390xHw() == 11.0f ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_float_2.cs
+++ b/src/s390tests/tests/call_args_float_2.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static float addTwo(float a, float b) => a + b;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static float s390xHw() => addTwo(11.0f, 22.0f);
+
+    static int Main() => s390xHw() == 33.0f ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_float_4.cs
+++ b/src/s390tests/tests/call_args_float_4.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static float addFour(float a, float b, float c, float d) => a + b + c + d;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static float s390xHw() => addFour(1.0f, 2.0f, 3.0f, 4.0f);
+
+    static int Main() => s390xHw() == 10.0f ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_long_1.cs
+++ b/src/s390tests/tests/call_args_long_1.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static long addOne(long x) => x + 1;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static long s390xHw() => addOne(10);
+
+    static int Main() => s390xHw() == 11 ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_long_2.cs
+++ b/src/s390tests/tests/call_args_long_2.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static long addTwo(long a, long b) => a + b;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static long s390xHw() => addTwo(11, 22);
+
+    static int Main() => s390xHw() == 33 ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_short_1.cs
+++ b/src/s390tests/tests/call_args_short_1.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static short addOne(short x) => (short)(x + 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static short s390xHw() => addOne(10);
+
+    static int Main() => s390xHw() == 11 ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_uint_1.cs
+++ b/src/s390tests/tests/call_args_uint_1.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static uint addOne(uint x) => x + 1;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static uint s390xHw() => addOne(10);
+
+    static int Main() => s390xHw() == 11 ? 0 : 1;
+}

--- a/src/s390tests/tests/call_args_ulong_1.cs
+++ b/src/s390tests/tests/call_args_ulong_1.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong addOne(ulong x) => x + 1;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong s390xHw() => addOne(10);
+
+    static int Main() => s390xHw() == 11 ? 0 : 1;
+}

--- a/src/s390tests/tests/wfadb.cs
+++ b/src/s390tests/tests/wfadb.cs
@@ -1,0 +1,27 @@
+using System;
+
+public class S390xInstructionTest
+{
+    public static int Main()
+    {
+        int result = s390xHw();
+        return result == 0 ? 0 : 1;
+    }
+
+    static double id(double x) { return x; }
+
+    public static int s390xHw()
+    {
+        double a = id(1.0);
+        double b = id(2.0);
+        double c = id(3.0);
+        double d = id(4.0);
+        double e = id(5.0);
+        double f = id(6.0);
+        double g = id(7.0);
+        double h = id(8.0);
+        double i = id(9.0);
+        double sum = a + b + c + d + e + f + g + h + i;
+        return sum == 45.0 ? 0 : 1;
+    }
+}

--- a/src/s390tests/tests/wfasb.cs
+++ b/src/s390tests/tests/wfasb.cs
@@ -1,0 +1,27 @@
+using System;
+
+public class S390xInstructionTest
+{
+    public static int Main()
+    {
+        int result = s390xHw();
+        return result == 0 ? 0 : 1;
+    }
+
+    static float id(float x) { return x; }
+
+    public static int s390xHw()
+    {
+        float a = id(1.0f);
+        float b = id(2.0f);
+        float c = id(3.0f);
+        float d = id(4.0f);
+        float e = id(5.0f);
+        float f = id(6.0f);
+        float g = id(7.0f);
+        float h = id(8.0f);
+        float i = id(9.0f);
+        float sum = a + b + c + d + e + f + g + h + i;
+        return sum == 45.0f ? 0 : 1;
+    }
+}

--- a/src/s390tests/tests/wfcdb.cs
+++ b/src/s390tests/tests/wfcdb.cs
@@ -1,0 +1,26 @@
+using System;
+
+public class S390xInstructionTest
+{
+    public static int Main()
+    {
+        int result = s390xHw();
+        return result == 0 ? 0 : 1;
+    }
+
+    static double id(double x) { return x; }
+
+    public static int s390xHw()
+    {
+        double a = id(1.0);
+        double b = id(2.0);
+        double c = id(3.0);
+        double d = id(4.0);
+        double e = id(5.0);
+        double f = id(6.0);
+        double g = id(7.0);
+        double h = id(8.0);
+        double i = id(8.0);
+        return (h == i && a < b && c < d && e < f) ? 0 : 1;
+    }
+}

--- a/src/s390tests/tests/wfcsb.cs
+++ b/src/s390tests/tests/wfcsb.cs
@@ -1,0 +1,26 @@
+using System;
+
+public class S390xInstructionTest
+{
+    public static int Main()
+    {
+        int result = s390xHw();
+        return result == 0 ? 0 : 1;
+    }
+
+    static float id(float x) { return x; }
+
+    public static int s390xHw()
+    {
+        float a = id(1.0f);
+        float b = id(2.0f);
+        float c = id(3.0f);
+        float d = id(4.0f);
+        float e = id(5.0f);
+        float f = id(6.0f);
+        float g = id(7.0f);
+        float h = id(8.0f);
+        float i = id(8.0f);
+        return (h == i && a < b && c < d && e < f) ? 0 : 1;
+    }
+}

--- a/src/s390tests/tests/wfddb.cs
+++ b/src/s390tests/tests/wfddb.cs
@@ -1,0 +1,28 @@
+using System;
+
+public class S390xInstructionTest
+{
+    public static int Main()
+    {
+        int result = s390xHw();
+        return result == 0 ? 0 : 1;
+    }
+
+    static double id(double x) { return x; }
+
+    public static int s390xHw()
+    {
+        double a = id(1.0);
+        double b = id(2.0);
+        double c = id(3.0);
+        double d = id(4.0);
+        double e = id(5.0);
+        double f = id(6.0);
+        double g = id(7.0);
+        double h = id(8.0);
+        double i = id(100.0);
+        double result = i / b;
+        double keep = a + c + d + e + f + g + h;
+        return (result == 50.0 && keep == 34.0) ? 0 : 1;
+    }
+}

--- a/src/s390tests/tests/wfdsb.cs
+++ b/src/s390tests/tests/wfdsb.cs
@@ -1,0 +1,28 @@
+using System;
+
+public class S390xInstructionTest
+{
+    public static int Main()
+    {
+        int result = s390xHw();
+        return result == 0 ? 0 : 1;
+    }
+
+    static float id(float x) { return x; }
+
+    public static int s390xHw()
+    {
+        float a = id(1.0f);
+        float b = id(2.0f);
+        float c = id(3.0f);
+        float d = id(4.0f);
+        float e = id(5.0f);
+        float f = id(6.0f);
+        float g = id(7.0f);
+        float h = id(8.0f);
+        float i = id(100.0f);
+        float result = i / b;
+        float keep = a + c + d + e + f + g + h;
+        return (result == 50.0f && keep == 34.0f) ? 0 : 1;
+    }
+}

--- a/src/s390tests/tests/wflcdb.cs
+++ b/src/s390tests/tests/wflcdb.cs
@@ -1,0 +1,28 @@
+using System;
+
+public class S390xInstructionTest
+{
+    public static int Main()
+    {
+        int result = s390xHw();
+        return result == 0 ? 0 : 1;
+    }
+
+    static double id(double x) { return x; }
+
+    public static int s390xHw()
+    {
+        double a = id(1.0);
+        double b = id(2.0);
+        double c = id(3.0);
+        double d = id(4.0);
+        double e = id(5.0);
+        double f = id(6.0);
+        double g = id(7.0);
+        double h = id(8.0);
+        double i = id(9.0);
+        double neg = -i;
+        double sum = a + b + c + d + e + f + g + h;
+        return (neg + sum) == 27.0 ? 0 : 1;
+    }
+}

--- a/src/s390tests/tests/wflcsb.cs
+++ b/src/s390tests/tests/wflcsb.cs
@@ -1,0 +1,28 @@
+using System;
+
+public class S390xInstructionTest
+{
+    public static int Main()
+    {
+        int result = s390xHw();
+        return result == 0 ? 0 : 1;
+    }
+
+    static float id(float x) { return x; }
+
+    public static int s390xHw()
+    {
+        float a = id(1.0f);
+        float b = id(2.0f);
+        float c = id(3.0f);
+        float d = id(4.0f);
+        float e = id(5.0f);
+        float f = id(6.0f);
+        float g = id(7.0f);
+        float h = id(8.0f);
+        float i = id(9.0f);
+        float neg = -i;
+        float sum = a + b + c + d + e + f + g + h;
+        return (neg + sum) == 27.0f ? 0 : 1;
+    }
+}

--- a/src/s390tests/tests/wfmdb.cs
+++ b/src/s390tests/tests/wfmdb.cs
@@ -1,0 +1,27 @@
+using System;
+
+public class S390xInstructionTest
+{
+    public static int Main()
+    {
+        int result = s390xHw();
+        return result == 0 ? 0 : 1;
+    }
+
+    static double id(double x) { return x; }
+
+    public static int s390xHw()
+    {
+        double a = id(1.0);
+        double b = id(2.0);
+        double c = id(3.0);
+        double d = id(4.0);
+        double e = id(5.0);
+        double f = id(6.0);
+        double g = id(7.0);
+        double h = id(2.0);
+        double i = id(3.0);
+        double result = a * b * c * d * e * f * g * h * i;
+        return result == 30240.0 ? 0 : 1;
+    }
+}

--- a/src/s390tests/tests/wfmsb.cs
+++ b/src/s390tests/tests/wfmsb.cs
@@ -1,0 +1,27 @@
+using System;
+
+public class S390xInstructionTest
+{
+    public static int Main()
+    {
+        int result = s390xHw();
+        return result == 0 ? 0 : 1;
+    }
+
+    static float id(float x) { return x; }
+
+    public static int s390xHw()
+    {
+        float a = id(1.0f);
+        float b = id(2.0f);
+        float c = id(3.0f);
+        float d = id(4.0f);
+        float e = id(5.0f);
+        float f = id(6.0f);
+        float g = id(7.0f);
+        float h = id(2.0f);
+        float i = id(3.0f);
+        float result = a * b * c * d * e * f * g * h * i;
+        return result == 30240.0f ? 0 : 1;
+    }
+}

--- a/src/s390tests/tests/wfsdb.cs
+++ b/src/s390tests/tests/wfsdb.cs
@@ -1,0 +1,27 @@
+using System;
+
+public class S390xInstructionTest
+{
+    public static int Main()
+    {
+        int result = s390xHw();
+        return result == 0 ? 0 : 1;
+    }
+
+    static double id(double x) { return x; }
+
+    public static int s390xHw()
+    {
+        double a = id(1.0);
+        double b = id(2.0);
+        double c = id(3.0);
+        double d = id(4.0);
+        double e = id(5.0);
+        double f = id(6.0);
+        double g = id(7.0);
+        double h = id(8.0);
+        double i = id(100.0);
+        double result = i - a - b - c - d - e - f - g - h;
+        return result == 64.0 ? 0 : 1;
+    }
+}

--- a/src/s390tests/tests/wfssb.cs
+++ b/src/s390tests/tests/wfssb.cs
@@ -1,0 +1,27 @@
+using System;
+
+public class S390xInstructionTest
+{
+    public static int Main()
+    {
+        int result = s390xHw();
+        return result == 0 ? 0 : 1;
+    }
+
+    static float id(float x) { return x; }
+
+    public static int s390xHw()
+    {
+        float a = id(1.0f);
+        float b = id(2.0f);
+        float c = id(3.0f);
+        float d = id(4.0f);
+        float e = id(5.0f);
+        float f = id(6.0f);
+        float g = id(7.0f);
+        float h = id(8.0f);
+        float i = id(100.0f);
+        float result = i - a - b - c - d - e - f - g - h;
+        return result == 64.0f ? 0 : 1;
+    }
+}


### PR DESCRIPTION
This PR aligns s390x floating-point argument handling with the current ABI direction by mapping FP argument registers to F0/F2/F4/F6, updating the related target register tables/masks, and adding the required s390x-specific float arg mapping/codegen ordering updates. 

sample program
```
[medha@t8360036 cmp]$ cat Program.cs 
class Program
{
    static float addOne(float x) => x + 1.0f;

    static float s390xHw() => addOne(10.0f);

    static int Main() => s390xHw() == 11.0f ? 0 : 1;
}
```
disassembly dump:
```
Thread 1 "corerun" hit Breakpoint 1, emitter::emitOutputInstr (this=0x2aa0029be80, ig=0x2aa002a1998, id=0x2aa002a1c88, dp=0x3ffffff08f0) at /home/medha/coreclr/port/runtime/src/coreclr/jit/emits390x.cpp:10035
10035        assert(ins == INS_ret);
(gdb) print this->emitComp->info.compMethodName
$3 = 0x2aa0029b858 "s390xHw"
(gdb) disass (dst+writeableOffset-100), (dst+writeableOffset)
Dump of assembler code from 0x2aa0029a396 to 0x2aa0029a3fa:
  0x000002aa0029a396: ic   %r11,3007(%r8,%r14)
  0x000002aa0029a39a: srp   36(6,%r0),2308(%r11),8
  0x000002aa0029a3a0: .long  0x00bfe3f0
  0x000002aa0029a3a4: .long  0xff50ff71
  0x000002aa0029a3a8: stg   %r11,0(%r15)
  0x000002aa0029a3ae: lgr   %r11,%r15
  0x000002aa0029a3b2: iihf  %r1,1023
  0x000002aa0029a3b8: iilf  %r1,2012706096
  0x000002aa0029a3be: l    %r1,0(%r1)
  0x000002aa0029a3c2: chi   %r1,0
  0x000002aa0029a3c6: jge   0x2aa0029a3d2
  0x000002aa0029a3cc: brasl  %r14,0x2aa7f42b7d8
  0x000002aa0029a3d2: iihf  %r1,1092616192
  0x000002aa0029a3d8: iilf  %r1,0
  0x000002aa0029a3de: ldgr  %f0,%r1
  0x000002aa0029a3e2: brasl  %r14,0x2aa0057a718
  0x000002aa0029a3e8: stey  %f0,164(%r15)
  0x000002aa0029a3ee: ley   %f0,164(%r15)
  0x000002aa0029a3f4: lmg   %r11,%r15,264(%r15)
End of assembler dump.
(gdb) c
Continuing.
Jitted Function name is addOne

Thread 1 "corerun" hit Breakpoint 1, emitter::emitOutputInstr (this=0x2aa0029be80, ig=0x2aa002a1528, id=0x2aa002a18b0, dp=0x3fffffeff90) at /home/medha/coreclr/port/runtime/src/coreclr/jit/emits390x.cpp:10035
10035        assert(ins == INS_ret);
(gdb) print this->emitComp->info.compMethodName
$4 = 0x2aa0029b858 "addOne"
(gdb) disass (dst+writeableOffset-100), (dst+writeableOffset)
Dump of assembler code from 0x2aa0029a394 to 0x2aa0029a3f8:
  0x000002aa0029a394: .long  0x77fa4430
  0x000002aa0029a398: stmg  %r11,%r15,88(%r15)
  0x000002aa0029a39e: lgr   %r11,%r15
  0x000002aa0029a3a2: lay   %r15,-176(%r15)
  0x000002aa0029a3a8: stg   %r11,0(%r15)
  0x000002aa0029a3ae: lgr   %r11,%r15
  0x000002aa0029a3b2: stey  %f0,164(%r15)
  0x000002aa0029a3b8: iihf  %r1,1023
  0x000002aa0029a3be: iilf  %r1,2012706096
  0x000002aa0029a3c4: l    %r1,0(%r1)
  0x000002aa0029a3c8: chi   %r1,0
  0x000002aa0029a3cc: jge   0x2aa0029a3d8
  0x000002aa0029a3d2: brasl  %r14,0x2aa7f42b768
  0x000002aa0029a3d8: ley   %f0,164(%r15)
  0x000002aa0029a3de: iihf  %r1,1065353216
  0x000002aa0029a3e4: iilf  %r1,0
  0x000002aa0029a3ea: ldgr  %f1,%r1
  0x000002aa0029a3ee: aebr  %f0,%f1
  0x000002aa0029a3f2: lmg   %r11,%r15,264(%r15)
End of assembler dump.
```
TestLogs:


[PASS] xrk

============================================================
FINAL SUMMARY
============================================================
Total Tests : 106
Passed      : 79
Failed      : 27

============================================================
============================================================                                                                                                                                                                                                                   
PASSED TESTS                                                                                                                                                                                                                                                                   
============================================================                                                                                                                                                                                                                   
afi                                                                                                                                                                                                                                                                            
agfi                                                                                                                                                                                                                                                                           
agrk
ark
beq
bge
bgt
ble
blt
bne
call_args_bool_1
call_args_byte_1
call_args_char_1
call_args_double_1
call_args_double_2
call_args_double_4
call_args_float_1
call_args_float_2
call_args_float_4
call_args_int_1
call_args_int_2
call_args_int_5
call_args_long_1
call_args_long_2
call_args_short_1
call_args_uint_1
call_args_ulong_1
cfdbr
cfebr
cfi
cgdbr
cgebr
cgfi
chi
clfdbr
clfebr
clgdbr
clgebr
dlgr
dlr
dr
dsgr
iihf
lay
l
lgb
lg
lgfi
lgfr
lgh
lgr
llc
llgh
msfi
msgfi
msgrkc
msrkc
ncrk
ngrk
ni
nihf
nrk
ogrk
oill
ork
sgrk
slag
sllg
srag
srk
srlg
stc
st
stg
sth
xgrk
xi
xihf
xrk

============================================================
FAILED TESTS
============================================================
adbr
aebr
cdbr
cebr
cgr
clfi
clgfi
clgr
clr
cr
ddbr
debr
iilf
ldebr
ldy
ledbr
ley
llgfr
lmg
mdbr
meebr
sdbr
sebr
std
stdy
stey
stmg