### PR TITLE
implement prolog block-init zeroing for local frame

### DIFF
--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -5788,21 +5788,6 @@ void CodeGen::genZeroInitFrame(unsigned frameSize, regNumber initReg, bool* pIni
     // Get frame start address: lay rAddr, 0(r15)
     GetEmitter()->emitIns_R_R_I(INS_lay, EA_PTRSIZE, rAddr, REG_SPBASE, 0);
 
-    // Emit zero store; if displacement is out of encodable RXY range, materialize
-    // full address in a temp register (iihf/iilf sequence via instGen_Set_Reg_To_Imm)
-    // and store with displacement 0.
-    auto emitZeroStore = [&](instruction ins, emitAttr attr, int offset) {
-        if (emitter::emitIns_valid_imm_for_ldst_offset(offset, attr))
-        {
-            GetEmitter()->emitIns_R_R_I(ins, attr, rZero, rAddr, offset);
-            return;
-        }
-
-        instGen_Set_Reg_To_Imm(EA_PTRSIZE, rTmpAddr, offset);
-        GetEmitter()->emitIns_R_R(INS_agr, EA_PTRSIZE, rTmpAddr, rAddr);
-        GetEmitter()->emitIns_R_R_I(ins, attr, rZero, rTmpAddr, 0);
-    };
-
     // Simple approach: Just store zeros in a loop (unrolled)
     unsigned numDoubleWords = frameSize / 8;
     unsigned remainder = frameSize % 8;
@@ -6053,8 +6038,28 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
     assert(genUseBlockInit);
     assert(untrLclHi > untrLclLo);
 
-    regNumber zeroReg = genGetZeroReg(initReg, pInitRegZeroed);
+    regNumber zeroReg  = genGetZeroReg(initReg, pInitRegZeroed);
+    regNumber frameReg = genFramePointerReg();
+    // Scratch for out-of-range displacements; must not clobber the zero register
+    regNumber rTmpAddr = (zeroReg != REG_R1) ? REG_R1 : REG_R2;
     int       offset  = untrLclLo;
+
+    // Emit zero store via RXY (stg/sty/stcy). If the displacement is outside the
+    // encodable 20-bit signed range, materialize FP+offset in a temp and store at disp 0.
+    auto emitZeroStore = [&](instruction ins, emitAttr attr, int offs) {
+        if (emitter::emitIns_valid_imm_for_ldst_offset(offs, attr))
+        {
+            GetEmitter()->emitIns_R_R_I(ins, attr, zeroReg, frameReg, offs);
+            return;
+        }
+        if (rTmpAddr == initReg)
+        {
+            *pInitRegZeroed = false;
+        }
+        instGen_Set_Reg_To_Imm(EA_PTRSIZE, rTmpAddr, offs);
+        GetEmitter()->emitIns_R_R(INS_agr, EA_PTRSIZE, rTmpAddr, frameReg);
+        GetEmitter()->emitIns_R_R_I(ins, attr, zeroReg, rTmpAddr, 0);
+    };
 
     while ((offset + (int)REGSIZE_BYTES) <= untrLclHi)
     {

--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -6033,194 +6033,30 @@ void CodeGen::genSetPSPSym(regNumber initReg, bool* pInitRegZeroed)
 //
 void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNumber initReg, bool* pInitRegZeroed)
 {
-    _ASSERTE(!"NYI");
-#if 0
     assert(compiler->compGeneratingProlog);
     assert(genUseBlockInit);
     assert(untrLclHi > untrLclLo);
 
-    int bytesToWrite = untrLclHi - untrLclLo;
+    regNumber zeroReg = genGetZeroReg(initReg, pInitRegZeroed);
+    int       offset  = untrLclLo;
 
-    const regNumber zeroSimdReg          = REG_ZERO_INIT_FRAME_SIMD;
-    bool            simdRegZeroed        = false;
-    const int       simdRegPairSizeBytes = 2 * FP_REGSIZE_BYTES;
-
-    regNumber addrReg = REG_ZERO_INIT_FRAME_REG1;
-
-    if (addrReg == initReg)
+    while ((offset + (int)REGSIZE_BYTES) <= untrLclHi)
     {
-        *pInitRegZeroed = false;
+        GetEmitter()->emitIns_R_R_I(INS_stg, EA_8BYTE, zeroReg, genFramePointerReg(), offset);
+        offset += REGSIZE_BYTES;
     }
 
-    int addrOffset = 0;
-
-    // The following invariants are held below:
-    //
-    //   1) [addrReg, #addrOffset] points at a location where next chunk of zero bytes will be written;
-    //   2) bytesToWrite specifies the number of bytes on the frame to initialize;
-    //   3) if simdRegZeroed is true then 128-bit wide zeroSimdReg contains zeroes.
-
-    const int bytesUseZeroingLoop = 192;
-
-    if (bytesToWrite >= bytesUseZeroingLoop)
+    if ((offset + (int)sizeof(int)) <= untrLclHi)
     {
-        // Generates the following code:
-        //
-        // When the size of the region is greater than or equal to 256 bytes
-        // **and** DC ZVA instruction use is permitted
-        // **and** the instruction block size is configured to 64 bytes:
-        //
-        //    movi    v16.16b, #0
-        //    add     x9, fp, #(untrLclLo+64)
-        //    add     x10, fp, #(untrLclHi-64)
-        //    stp     q16, q16, [x9, #-64]
-        //    stp     q16, q16, [x9, #-32]
-        //    bfm     x9, xzr, #0, #5
-        //
-        // loop:
-        //    dc      zva, x9
-        //    add     x9, x9, #64
-        //    cmp     x9, x10
-        //    blo     loop
-        //
-        //    stp     q16, q16, [x10]
-        //    stp     q16, q16, [x10, #32]
-        //
-        // Otherwise:
-        //
-        //     movi    v16.16b, #0
-        //     add     x9, fp, #(untrLclLo-32)
-        //     mov     x10, #(bytesToWrite-64)
-        //
-        // loop:
-        //     stp     q16, q16, [x9, #32]
-        //     mov     x10, #(bytesToWrite-64)
-        //
-        // loop:
-        //     stp     q16, q16, [x9, #32]
-        //     stp     q16, q16, [x9, #64]!
-        //     subs    x10, x10, #64
-        //     bge     loop
-
-        const int bytesUseDataCacheZeroInstruction = 256;
-
-        GetEmitter()->emitIns_R_I(INS_movi, EA_16BYTE, zeroSimdReg, 0, INS_OPTS_16B);
-        simdRegZeroed = true;
-
-        if ((bytesToWrite >= bytesUseDataCacheZeroInstruction) &&
-            compiler->compOpportunisticallyDependsOn(InstructionSet_Dczva))
-        {
-            // The first and the last 64 bytes should be written with two stp q-reg instructions.
-            // This is in order to avoid **unintended** zeroing of the data by dc zva
-            // outside of [fp+untrLclLo, fp+untrLclHi) memory region.
-
-            genInstrWithConstant(INS_add, EA_PTRSIZE, addrReg, genFramePointerReg(), untrLclLo + 64, addrReg);
-            addrOffset = -64;
-
-            const regNumber endAddrReg = REG_ZERO_INIT_FRAME_REG2;
-
-            if (endAddrReg == initReg)
-            {
-                *pInitRegZeroed = false;
-            }
-
-            genInstrWithConstant(INS_add, EA_PTRSIZE, endAddrReg, genFramePointerReg(), untrLclHi - 64, endAddrReg);
-
-            GetEmitter()->emitIns_R_R_R_I(INS_stp, EA_16BYTE, zeroSimdReg, zeroSimdReg, addrReg, addrOffset);
-            addrOffset += simdRegPairSizeBytes;
-
-            GetEmitter()->emitIns_R_R_R_I(INS_stp, EA_16BYTE, zeroSimdReg, zeroSimdReg, addrReg, addrOffset);
-            addrOffset += simdRegPairSizeBytes;
-
-            assert(addrOffset == 0);
-
-            GetEmitter()->emitIns_R_R_I_I(INS_bfm, EA_PTRSIZE, addrReg, REG_ZR, 0, 5);
-            // addrReg points at the beginning of a cache line.
-
-            GetEmitter()->emitIns_R(INS_dczva, EA_PTRSIZE, addrReg);
-            GetEmitter()->emitIns_R_R_I(INS_add, EA_PTRSIZE, addrReg, addrReg, 64);
-            GetEmitter()->emitIns_R_R(INS_cmp, EA_PTRSIZE, addrReg, endAddrReg);
-            GetEmitter()->emitIns_J(INS_blo, NULL, -4);
-
-            addrReg      = endAddrReg;
-            bytesToWrite = 64;
-        }
-        else
-        {
-            genInstrWithConstant(INS_add, EA_PTRSIZE, addrReg, genFramePointerReg(), untrLclLo - 32, addrReg);
-            addrOffset = 32;
-
-            const regNumber countReg = REG_ZERO_INIT_FRAME_REG2;
-
-            if (countReg == initReg)
-            {
-                *pInitRegZeroed = false;
-            }
-
-            instGen_Set_Reg_To_Imm(EA_PTRSIZE, countReg, bytesToWrite - 64);
-
-            GetEmitter()->emitIns_R_R_R_I(INS_stp, EA_16BYTE, zeroSimdReg, zeroSimdReg, addrReg, 32);
-            GetEmitter()->emitIns_R_R_R_I(INS_stp, EA_16BYTE, zeroSimdReg, zeroSimdReg, addrReg, 64,
-                                          INS_OPTS_PRE_INDEX);
-
-            GetEmitter()->emitIns_R_R_I(INS_subs, EA_PTRSIZE, countReg, countReg, 64);
-            GetEmitter()->emitIns_J(INS_bge, NULL, -4);
-
-            bytesToWrite %= 64;
-        }
-    }
-    else
-    {
-        genInstrWithConstant(INS_add, EA_PTRSIZE, addrReg, genFramePointerReg(), untrLclLo, addrReg);
+        GetEmitter()->emitIns_R_R_I(INS_st, EA_4BYTE, zeroReg, genFramePointerReg(), offset);
+        offset += sizeof(int);
     }
 
-    if (bytesToWrite >= simdRegPairSizeBytes)
+    while (offset < untrLclHi)
     {
-        // Generates the following code:
-        //
-        //     movi    v16.16b, #0
-        //     stp     q16, q16, [x9, #addrOffset]
-        //     stp     q16, q16, [x9, #(addrOffset+32)]
-        // ...
-        //     stp     q16, q16, [x9, #(addrOffset+roundDown(bytesToWrite, 32))]
-
-        if (!simdRegZeroed)
-        {
-            GetEmitter()->emitIns_R_I(INS_movi, EA_16BYTE, zeroSimdReg, 0, INS_OPTS_16B);
-            simdRegZeroed = true;
-        }
-
-        for (; bytesToWrite >= simdRegPairSizeBytes; bytesToWrite -= simdRegPairSizeBytes)
-        {
-            GetEmitter()->emitIns_R_R_R_I(INS_stp, EA_16BYTE, zeroSimdReg, zeroSimdReg, addrReg, addrOffset);
-            addrOffset += simdRegPairSizeBytes;
-        }
+        GetEmitter()->emitIns_R_R_I(INS_stc, EA_1BYTE, zeroReg, genFramePointerReg(), offset);
+        offset++;
     }
-
-    const int regPairSizeBytes = 2 * REGSIZE_BYTES;
-
-    if (bytesToWrite >= regPairSizeBytes)
-    {
-        GetEmitter()->emitIns_R_R_R_I(INS_stp, EA_PTRSIZE, REG_ZR, REG_ZR, addrReg, addrOffset);
-        addrOffset += regPairSizeBytes;
-        bytesToWrite -= regPairSizeBytes;
-    }
-
-    if (bytesToWrite >= REGSIZE_BYTES)
-    {
-        GetEmitter()->emitIns_R_R_I(INS_str, EA_PTRSIZE, REG_ZR, addrReg, addrOffset);
-        addrOffset += REGSIZE_BYTES;
-        bytesToWrite -= REGSIZE_BYTES;
-    }
-
-    if (bytesToWrite == sizeof(int))
-    {
-        GetEmitter()->emitIns_R_R_I(INS_str, EA_4BYTE, REG_ZR, addrReg, addrOffset);
-        bytesToWrite = 0;
-    }
-
-    assert(bytesToWrite == 0);
-#endif
 }
 
 

--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -5780,12 +5780,28 @@ void CodeGen::genZeroInitFrame(unsigned frameSize, regNumber initReg, bool* pIni
 
     regNumber rZero = REG_R0;
     regNumber rAddr = (initReg != REG_NA) ? initReg : REG_R1;
+    regNumber rTmpAddr = (rAddr != REG_R1) ? REG_R1 : REG_R2;
 
     // Zero out r0: xgr r0, r0
     GetEmitter()->emitIns_R_R(INS_xgr, EA_8BYTE, rZero, rZero);
 
     // Get frame start address: lay rAddr, 0(r15)
     GetEmitter()->emitIns_R_R_I(INS_lay, EA_PTRSIZE, rAddr, REG_SPBASE, 0);
+
+    // Emit zero store; if displacement is out of encodable RXY range, materialize
+    // full address in a temp register (iihf/iilf sequence via instGen_Set_Reg_To_Imm)
+    // and store with displacement 0.
+    auto emitZeroStore = [&](instruction ins, emitAttr attr, int offset) {
+        if (emitter::emitIns_valid_imm_for_ldst_offset(offset, attr))
+        {
+            GetEmitter()->emitIns_R_R_I(ins, attr, rZero, rAddr, offset);
+            return;
+        }
+
+        instGen_Set_Reg_To_Imm(EA_PTRSIZE, rTmpAddr, offset);
+        GetEmitter()->emitIns_R_R(INS_agr, EA_PTRSIZE, rTmpAddr, rAddr);
+        GetEmitter()->emitIns_R_R_I(ins, attr, rZero, rTmpAddr, 0);
+    };
 
     // Simple approach: Just store zeros in a loop (unrolled)
     unsigned numDoubleWords = frameSize / 8;
@@ -6048,13 +6064,13 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
 
     if ((offset + (int)sizeof(int)) <= untrLclHi)
     {
-        GetEmitter()->emitIns_R_R_I(INS_st, EA_4BYTE, zeroReg, genFramePointerReg(), offset);
+        GetEmitter()->emitIns_R_R_I(INS_sty, EA_4BYTE, zeroReg, genFramePointerReg(), offset);
         offset += sizeof(int);
     }
 
     while (offset < untrLclHi)
     {
-        GetEmitter()->emitIns_R_R_I(INS_stc, EA_1BYTE, zeroReg, genFramePointerReg(), offset);
+        GetEmitter()->emitIns_R_R_I(INS_stcy, EA_1BYTE, zeroReg, genFramePointerReg(), offset);
         offset++;
     }
 }

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1207,6 +1207,8 @@ protected:
                 case INS_iihf:
                 case INS_iilf:
                 case INS_stg:
+                case INS_sty:
+                case INS_stcy:
                 case INS_lg:
                 case INS_lay:
                 case INS_ley:

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -1749,7 +1749,8 @@ emitter::code_t emitter::emitInsCode(instruction ins, insFormat fmt)
 // true if this 'imm' can be encoded as the offset in a ldr/str instruction
 /*static*/ bool emitter::emitIns_valid_imm_for_ldst_offset(INT64 imm, emitAttr attr)
 {
-    _ASSERTE(!"NYI");
+    (void)attr;
+    return isValidSimm<20>(imm);
 #if 0
     if (imm == 0)
         return true; // Encodable using IF_LS_2A

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -10054,7 +10054,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
         case INS_st:
             imm = emitGetInsSC(id); //get instruction's constant value
-            assert((imm >= 0) && (imm <= 2047)); // 11 bit imm unsigned value
+            assert((imm >= 0) && (imm <=4095)); 
             op = emitInsCode(ins, fmt);
             S390_RX_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
             break;
@@ -10062,6 +10062,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_stg:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
+            assert((imm >= -524288) && (imm <= 524287));
             S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
             break;
 

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -7452,6 +7452,7 @@ void emitter::emitIns_R_S(instruction ins, emitAttr attr, regNumber reg1, int va
     switch (ins)
     {
         case INS_stc:
+        case INS_stcy:
         case INS_lgb:
         case INS_llgc:
             scale = 0;
@@ -7468,6 +7469,7 @@ void emitter::emitIns_R_S(instruction ins, emitAttr attr, regNumber reg1, int va
 //            break;
 
         case INS_st:
+        case INS_sty:
         case INS_stg:
         case INS_l:
         case INS_lg:
@@ -10054,9 +10056,16 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
         case INS_st:
             imm = emitGetInsSC(id); //get instruction's constant value
-            assert((imm >= 0) && (imm <=4095)); 
+            assert((imm >= 0) && (imm <= 4095)); 
             op = emitInsCode(ins, fmt);
             S390_RX_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            break;
+
+        case INS_sty:
+            op = emitInsCode(ins, fmt);
+            imm = emitGetInsSC(id);
+            assert((imm >= -524288) && (imm <= 524287));
+            S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
             break;
 
         case INS_stg:
@@ -10066,6 +10075,12 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
             break;
 
+        case INS_stcy:
+            op = emitInsCode(ins, fmt);
+            imm = emitGetInsSC(id);
+            assert((imm >= -524288) && (imm <= 524287));
+            S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            break;
 	    
         case INS_stmg:
             op = emitInsCode(ins, fmt);

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -2759,7 +2759,8 @@ void CodeGen::instGen_Set_Reg_To_Zero(emitAttr size, regNumber reg, insFlags fla
 #elif defined(TARGET_ARM64)
     GetEmitter()->emitIns_Mov(INS_mov, size, reg, REG_ZR, /* canSkip */ true);
 #elif defined(TARGET_S390X)
-    GetEmitter()->emitIns_Mov(INS_lgfi, size, reg, reg, /* canSkip */ true);
+    // s390xmarker: need adhere to emitIns_Mov once implemented
+    GetEmitter()->emitIns_R_I(INS_lgfi, size, reg, 0);
 #elif defined(TARGET_LOONGARCH64)
     GetEmitter()->emitIns_R_R_I(INS_ori, size, reg, REG_R0, 0);
 #elif defined(TARGET_RISCV64)

--- a/src/coreclr/jit/instrss390x.h
+++ b/src/coreclr/jit/instrss390x.h
@@ -159,8 +159,10 @@ INST(slag,             "slag",                 0,              0xEB0B)
 
 //// R_R_I
 INST(stc,		"stc",			0,		0x42)
+INST(stcy,		"stcy",		        0,		0xe372)
 INST(sth,		"sth",			0,		0x40)
 INST(st,		"st",			0,		0x50)
+INST(sty,		"sty",			0,		0xe350)
 INST(stg,		"stg",			0,		0xe324)
 INST(std,		"std",			0,		0x60)
 INST(lay,		"lay",			0,		0xe371)

--- a/src/coreclr/jit/instrss390x.h
+++ b/src/coreclr/jit/instrss390x.h
@@ -159,7 +159,7 @@ INST(slag,             "slag",                 0,              0xEB0B)
 
 //// R_R_I
 INST(stc,		"stc",			0,		0x42)
-INST(stcy,		"stcy",		        0,		0xe372)
+INST(stcy,		"stcy",		    0,		0xe372)
 INST(sth,		"sth",			0,		0x40)
 INST(st,		"st",			0,		0x50)
 INST(sty,		"sty",			0,		0xe350)


### PR DESCRIPTION
Implemented genZeroInitFrameUsingBlockInit to replace the existing NYI assert path in prolog frame zero-initialization.

```
using System.Runtime.CompilerServices;

class Program
{
    [MethodImpl(MethodImplOptions.NoInlining)]
    static int oneArg(int[] a) => (a == null) ? 0 : 1;

    [MethodImpl(MethodImplOptions.NoInlining)]
    static int twoArgs(int[] a, int[] b) => ((a == null) || (b == null)) ? 0 : 2;

    [MethodImpl(MethodImplOptions.NoInlining)]
    static int s390xHw()
    {
        int[] x = new int[2];
        int[] y = new int[3];
        oneArg(x);
        twoArgs(x, y);
        return 0;
    }

    static int Main() => s390xHw();
}
```

```
Assert failure: !"NYI"
File: .../src/coreclr/jit/codegens390x.cpp:6061
```
