### PR TITLE
remove assertion for lowering on putarg_stk

### DIFF
--- a/src/coreclr/jit/lowers390x.cpp
+++ b/src/coreclr/jit/lowers390x.cpp
@@ -836,7 +836,7 @@ void Lowering::ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenT
 //
 void Lowering::LowerPutArgStkOrSplit(GenTreePutArgStk* putArgNode)
 {
-    _ASSERTE(!"NYI");
+//GT_PUTARG_SPLIT is not present on s390x abi, anyways removed in mainline
     GenTree* src = putArgNode->Data();
 
     if (src->TypeIs(TYP_STRUCT))


### PR DESCRIPTION
remove assertion for putarg_stk
GT_PUTARG_SPLIT is not supported in s390x
abi and anyways this is removed in the mainline

https://github.com/dotnet/runtime/pull/116074