### PR TITLE
Implement inst_SETCC

### DIFF
--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -4091,7 +4091,39 @@ const CodeGen::GenConditionDesc CodeGen::GenConditionDesc::map[32]
 //
 void CodeGen::inst_SETCC(GenCondition condition, var_types type, regNumber dstReg)
 {
-    _ASSERTE(!"NYI");
+    assert(varTypeIsIntegral(type));
+    assert(genIsValidIntReg(dstReg));
+    instruction branchIns;
+    switch (condition.GetCode())
+    {
+        case GenCondition::EQ:  branchIns = INS_beq; break;
+        case GenCondition::NE:  branchIns = INS_bne; break;
+        case GenCondition::SLT: branchIns = INS_blt; break;
+        case GenCondition::SLE: branchIns = INS_ble; break;
+        case GenCondition::SGE: branchIns = INS_bge; break;
+        case GenCondition::SGT: branchIns = INS_bgt; break;
+        case GenCondition::ULT: branchIns = INS_blt; break;
+        case GenCondition::ULE: branchIns = INS_ble; break;
+        case GenCondition::UGE: branchIns = INS_bge; break;
+        case GenCondition::UGT: branchIns = INS_bgt; break;
+        case GenCondition::FEQ: branchIns = INS_beq; break;
+        case GenCondition::FNE: branchIns = INS_bne; break;
+        case GenCondition::FLT: branchIns = INS_blt; break;
+        case GenCondition::FLE: branchIns = INS_ble; break;
+        case GenCondition::FGE: branchIns = INS_bge; break;
+        case GenCondition::FGT: branchIns = INS_bgt; break;
+        default: unreached();
+    }
+    // Materialize 0/1:
+    //   lgfi  dstReg, 1       ; assume true
+    //   brcl  <cond>, skip    ; if condition met, skip the "load 0"
+    //   lgfi  dstReg, 0       ; condition not met
+    // skip:
+    GetEmitter()->emitIns_R_I(INS_lgfi, EA_4BYTE, dstReg, 1, INS_OPTS_NONE,
+                              INS_SCALABLE_OPTS_NONE DEBUGARG(0) DEBUGARG(GTF_EMPTY));
+    GetEmitter()->emitIns_J(branchIns, nullptr, 1);
+    GetEmitter()->emitIns_R_I(INS_lgfi, EA_4BYTE, dstReg, 0, INS_OPTS_NONE,
+                              INS_SCALABLE_OPTS_NONE DEBUGARG(0) DEBUGARG(GTF_EMPTY));
 /*
     assert(varTypeIsIntegral(type));
     assert(genIsValidIntReg(dstReg));


### PR DESCRIPTION
```
using System;

public class S390xInstructionTest
{
    public static int Main()
    {
        int result = s390xHw();
        return result == 0 ? 0 : 1;
    }

    public static int s390xHw()
    {
        float a = 5.0f;
        float b = 3.0f;
        return (a > b) ? 0 : 64;
    }
}
```

``
   0x000002aa0029ac8c:  .long   0x000000d0
   0x000002aa0029ac90:  .long   0x000003ff
   0x000002aa0029ac94:  .long   0x77fc4358
   0x000002aa0029ac98:  stmg    %r11,%r15,88(%r15)
   0x000002aa0029ac9e:  lgr     %r11,%r15
   0x000002aa0029aca2:  lay     %r15,-176(%r15)
   0x000002aa0029aca8:  stg     %r11,0(%r15)
   0x000002aa0029acae:  lgr     %r11,%r15
   0x000002aa0029acb2:  st      %r0,164(%r15)
   0x000002aa0029acb6:  st      %r0,168(%r15)
   0x000002aa0029acba:  st      %r0,172(%r15)
   0x000002aa0029acbe:  st      %r0,176(%r15)
   0x000002aa0029acc2:  iihf    %r1,1023
   0x000002aa0029acc8:  iilf    %r1,2012837168
   0x000002aa0029acce:  l       %r1,0(%r1)
   0x000002aa0029acd2:  chi     %r1,0
   0x000002aa0029acd6:  jge     0x2aa0029ace2
   0x000002aa0029acdc:  brasl   %r14,0x2aa7f40c0d8
   0x000002aa0029ace2:  nopr
   0x000002aa0029ace4:  iihf    %r1,1084227584
   0x000002aa0029acea:  iilf    %r1,0
   0x000002aa0029acf0:  ldgr    %f0,%r1
   0x000002aa0029acf4:  stey    %f0,164(%r15)
   0x000002aa0029acfa:  iihf    %r1,1077936128
   0x000002aa0029ad00:  iilf    %r1,0
   0x000002aa0029ad06:  ldgr    %f0,%r1
   0x000002aa0029ad0a:  stey    %f0,168(%r15)
   0x000002aa0029ad10:  ley     %f0,164(%r15)
   0x000002aa0029ad16:  ley     %f1,168(%r15)
   0x000002aa0029ad1c:  cebr    %f0,%f1
   0x000002aa0029ad20:  jgh     0x2aa0029ad36
   0x000002aa0029ad26:  lgfi    %r1,64
   0x000002aa0029ad2c:  st      %r1,176(%r15)
   0x000002aa0029ad30:  jg      0x2aa0029ad40
   0x000002aa0029ad36:  lgfi    %r1,0
   0x000002aa0029ad3c:  st      %r1,176(%r15)
   0x000002aa0029ad40:  l       %r1,176(%r15)
   0x000002aa0029ad44:  st      %r1,172(%r15)
   0x000002aa0029ad48:  nopr
   0x000002aa0029ad4a:  l       %r2,172(%r15)
   0x000002aa0029ad4e:  lmg     %r11,%r15,264(%r15)
```