### PR TITLE
Fix JIT assert when zero-initializing structs

### DIFF
--- a/src/coreclr/jit/lowers390x.cpp
+++ b/src/coreclr/jit/lowers390x.cpp
@@ -688,7 +688,10 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
             if (size >= REGSIZE_BYTES)
             {
                 fill *= 0x0101010101010101LL;
-                src->gtType = TYP_LONG;
+                if( fill != 0)
+                {
+                    src->gtType = TYP_LONG;
+                }
             }
             else
             {

--- a/src/s390tests/tests/nestedStructs.cs
+++ b/src/s390tests/tests/nestedStructs.cs
@@ -1,0 +1,39 @@
+using System;
+
+public struct Point
+{
+    public int X;
+    public int Y;
+}
+
+public struct Rectangle
+{
+    public Point TopLeft;
+    public Point BottomRight;
+}
+
+public class S390xStructTest
+{
+    public static int s390xHw()
+    {
+        Rectangle rect = new Rectangle
+        {
+            TopLeft = new Point { X = 10, Y = 20 },
+            BottomRight = new Point { X = 30, Y = 40 }
+        };
+
+        return rect.BottomRight.Y;
+    }
+}
+
+public class Program
+{
+    public static int Main()
+    {
+        int result = S390xStructTest.s390xHw();
+        Console.WriteLine(result);
+
+        return result == 40 ? 0 : 1;
+    }
+}
+

--- a/src/s390tests/tests/structs2.cs
+++ b/src/s390tests/tests/structs2.cs
@@ -1,0 +1,38 @@
+using System;
+
+public struct Point
+{
+    public int X;
+    public int Y;
+}
+
+public struct Rectangle
+{
+    public Point TopLeft;
+    public Point BottomRight;
+}
+
+public class S390xStructTest
+{
+    public static int s390xHw()
+    {
+        // Zero-initialize the entire struct
+        Rectangle rect = new Rectangle();
+
+        return rect.TopLeft.X +
+               rect.TopLeft.Y +
+               rect.BottomRight.X +
+               rect.BottomRight.Y;
+    }
+}
+
+public class Program
+{
+    public static int Main()
+    {
+        int result = S390xStructTest.s390xHw();
+        Console.WriteLine(result);
+
+        return result == 0 ? 0 : 1;
+    }
+}


### PR DESCRIPTION
Zero fills must be left as a TYP_INT constant 
OperIsInitBlkOp() recognizes a zero-fill by its TYP_INT type, so converting it into TYP_LONG breaks that check; and since s390x has no zero register (unlike ARM), containing it would be invalid like what ARM originally did.
Non-zero fills are unchanged.