### PR TITLE
Add immediate range assertions for s390x emitter

### DIFF
--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -18,6 +18,16 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #if defined(TARGET_S390X)
 /*****************************************************************************/
 /*****************************************************************************/
+constexpr int Max12BitUnsigned = (1<<12) - 1;
+
+constexpr int Min16BitSigned = -(1<<15);
+constexpr int Max16BitSigned = (1<<15) - 1;
+
+constexpr int Min20BitSigned = -(1<<19);
+constexpr int Max20BitSigned = (1<<19)-1;
+
+constexpr long long Min32BitSigned = -(1LL << 31);
+constexpr long long Max32BitSigned = (1LL << 31) - 1;
 
 #include "instr.h"
 #include "emit.h"
@@ -10086,18 +10096,21 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_stmg:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
+	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RSY_a(dst, op, id->idReg1(), id->idReg2(), id->idReg3(), imm);
             break;
 
         case INS_lmg:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
+	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RSY_a(dst, op, id->idReg1(), id->idReg2(), id->idReg3(), imm);
             break;
 
         case INS_lay:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
+	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
             break;
 
@@ -10111,18 +10124,21 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_lg:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
+	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
             break;
 
         case INS_ley:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
+	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
             break;
 
         case INS_ldy:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
+	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
             break;
 
@@ -10133,6 +10149,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
         case INS_lgfi:
             imm = emitGetInsSC(id);
+	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
@@ -10151,30 +10168,35 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
         case INS_cfi:
             imm = emitGetInsSC(id);
+	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_cgfi:
             imm = emitGetInsSC(id);
+	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_clfi:
             imm = emitGetInsSC(id);
+	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_clgfi:
             imm = emitGetInsSC(id);
+	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_chi:
             imm = emitGetInsSC(id);
+	    assert((imm >= Min16BitSigned) && (imm <= Max16BitSigned)); // 16 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RI_a(dst, op, id->idReg1(), imm);
             break;
@@ -10327,12 +10349,14 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_stey:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
+	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
             break;
 
         case INS_stdy:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
+	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
             break;
 
@@ -10388,24 +10412,28 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
         case INS_afi:
             imm = emitGetInsSC(id);
+	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_agfi:
             imm = emitGetInsSC(id);
+	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_msfi:
             imm = emitGetInsSC(id);
+	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_msgfi:
             imm = emitGetInsSC(id);
+	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
@@ -10413,6 +10441,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_oill:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
+	    assert((imm >= Min16BitSigned) && (imm <= Max16BitSigned)); // 16 bit imm signed value
             S390_RI(dst, op, id->idReg1(), 0x80);
             break;
 
@@ -10432,12 +10461,14 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
         case INS_nihf:
             imm = emitGetInsSC(id);
+	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_xihf:
             imm = emitGetInsSC(id);
+	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
@@ -10465,6 +10496,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_srdl:
         case INS_srda:
             imm = emitGetInsSC(id);
+	    assert((imm >= 0) && (imm <= Max12BitUnsigned)); // unsigned 12 bits
             op  = emitInsCode(ins, fmt);
             S390_RS_a(dst, op, id->idReg1(), 0, 0, imm);
             break;

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -10096,21 +10096,21 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_stmg:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
+            assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RSY_a(dst, op, id->idReg1(), id->idReg2(), id->idReg3(), imm);
             break;
 
         case INS_lmg:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
+            assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RSY_a(dst, op, id->idReg1(), id->idReg2(), id->idReg3(), imm);
             break;
 
         case INS_lay:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
+            assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
             break;
 
@@ -10124,21 +10124,21 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_lg:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
+            assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
             break;
 
         case INS_ley:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
+            assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
             break;
 
         case INS_ldy:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
+            assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
             break;
 
@@ -10149,7 +10149,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
         case INS_lgfi:
             imm = emitGetInsSC(id);
-	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
+            assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
@@ -10168,35 +10168,35 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
         case INS_cfi:
             imm = emitGetInsSC(id);
-	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
+            assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_cgfi:
             imm = emitGetInsSC(id);
-	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
+            assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_clfi:
             imm = emitGetInsSC(id);
-	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
+            assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_clgfi:
             imm = emitGetInsSC(id);
-	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
+            assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_chi:
             imm = emitGetInsSC(id);
-	    assert((imm >= Min16BitSigned) && (imm <= Max16BitSigned)); // 16 bit imm signed value
+            assert((imm >= Min16BitSigned) && (imm <= Max16BitSigned)); // 16 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RI_a(dst, op, id->idReg1(), imm);
             break;
@@ -10349,14 +10349,14 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_stey:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
+            assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
             break;
 
         case INS_stdy:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-	    assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
+            assert((imm >= Min20BitSigned) && (imm <= Max20BitSigned)); // 20 bit imm signed value
             S390_RXY_a(dst, op, id->idReg1() - 16, 0, id->idReg2(), imm);
             break;
 
@@ -10412,28 +10412,28 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
         case INS_afi:
             imm = emitGetInsSC(id);
-	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
+            assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_agfi:
             imm = emitGetInsSC(id);
-	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
+            assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_msfi:
             imm = emitGetInsSC(id);
-	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
+            assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_msgfi:
             imm = emitGetInsSC(id);
-	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
+            assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
@@ -10441,7 +10441,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_oill:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
-	    assert((imm >= Min16BitSigned) && (imm <= Max16BitSigned)); // 16 bit imm signed value
+            assert((imm >= Min16BitSigned) && (imm <= Max16BitSigned)); // 16 bit imm signed value
             S390_RI(dst, op, id->idReg1(), 0x80);
             break;
 
@@ -10461,14 +10461,14 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
         case INS_nihf:
             imm = emitGetInsSC(id);
-	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
+            assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
 
         case INS_xihf:
             imm = emitGetInsSC(id);
-	    assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
+            assert((imm >= Min32BitSigned) && (imm <= Max32BitSigned)); // 32 bit imm signed value
             op = emitInsCode(ins, fmt);
             S390_RIL_a(dst, op, id->idReg1(), imm);
             break;
@@ -10496,7 +10496,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_srdl:
         case INS_srda:
             imm = emitGetInsSC(id);
-	    assert((imm >= 0) && (imm <= Max12BitUnsigned)); // unsigned 12 bits
+            assert((imm >= 0) && (imm <= Max12BitUnsigned)); // unsigned 12 bits
             op  = emitInsCode(ins, fmt);
             S390_RS_a(dst, op, id->idReg1(), 0, 0, imm);
             break;


### PR DESCRIPTION
## Summary

Adds immediate range assertions for the s390x emitter to validate instruction immediate operands during JIT code generation.

## Testing

- Built CoreCLR successfully on s390x.
- Ran the s390x test suite.
- Test results match the baseline; no additional failures were introduced by this change.