### PR TITLE
Fix overlapping stack slots

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -7071,8 +7071,13 @@ int Compiler::lvaAllocLocalAndSetVirtualOffset(unsigned lclNum, unsigned size, i
     /* Reserve space on the stack by bumping the frame size */
 
     lvaIncrementFrameSize(size);
+#if defined(TARGET_S390X)
+    lcl->SetStackOffset(stkOffs);
+    stkOffs += size;
+#else
     stkOffs += size;
     lcl->SetStackOffset(stkOffs);
+#endif
 
 #ifdef DEBUG
     if (verbose)

--- a/src/s390tests/tests/2d-JaggedArray.cs
+++ b/src/s390tests/tests/2d-JaggedArray.cs
@@ -1,0 +1,27 @@
+using System;
+
+public class S390xArrayTest
+{
+    public static int s390xHw()
+    {
+        int[][] matrix =
+        {
+            new int[] { 1, 2, 3 },
+            new int[] { 4, 5, 6 },
+            new int[] { 7, 8, 9 }
+        };
+
+        return matrix[1][2];
+    }
+}
+
+public class Program
+{
+    public static int Main()
+    {
+        int result = S390xArrayTest.s390xHw();
+        Console.WriteLine(result);
+
+        return result == 6 ? 0 : 1;
+    }
+}


### PR DESCRIPTION
on s390x, record the offset before advancing `stkOffs`, so it points at the start of the newly reserved slot instead of the end.