### PR TITLE
Jitted Write, WriteUnaligned and Validate functions

### DIFF
--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -729,15 +729,16 @@ void CodeGen::genCodeForBBlist()
                 }
 
                 break;
-
+#if defined(TARGET_S390X)
+//TODO s390x: HAS TO BE UNCOMMENTED LATER
             case BBJ_CALLFINALLY:
                 //block = genCallFinally(block);
                 break;
 
-//TODO: HAS TO BE REMOVED LATER
+//TODO s390x: THIS WHOLE CASE HAS TO BE REMOVED LATER
             case BBJ_CALLFINALLYRET:
                 break;
-
+#endif
             case BBJ_EHCATCHRET:
                 assert(compiler->UsesFunclets());
                 genEHCatchRet(block);

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -731,7 +731,11 @@ void CodeGen::genCodeForBBlist()
                 break;
 
             case BBJ_CALLFINALLY:
-                block = genCallFinally(block);
+                //block = genCallFinally(block);
+                break;
+
+//TODO: HAS TO BE REMOVED LATER
+            case BBJ_CALLFINALLYRET:
                 break;
 
             case BBJ_EHCATCHRET:

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -729,12 +729,14 @@ void CodeGen::genCodeForBBlist()
                 }
 
                 break;
-#if defined(TARGET_S390X)
 //TODO s390x: HAS TO BE UNCOMMENTED LATER
             case BBJ_CALLFINALLY:
-                //block = genCallFinally(block);
+#if !defined(TARGET_S390X)
+                block = genCallFinally(block);
+#endif
                 break;
 
+#if defined(TARGET_S390X)
 //TODO s390x: THIS WHOLE CASE HAS TO BE REMOVED LATER
             case BBJ_CALLFINALLYRET:
                 break;

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -739,7 +739,7 @@ var_types Compiler::getArgTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
                     useType         = TYP_UNKNOWN;
                 }
 
-#elif defined(TARGET_X86) || defined(TARGET_ARM) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64) ||defined (TARGET_S390X)
+#elif defined(TARGET_X86) || defined(TARGET_ARM) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
 
                 // Otherwise we pass this struct by value on the stack
                 // setup wbPassType and useType indicate that this is passed by value according to the X86/ARM32 ABI
@@ -766,7 +766,7 @@ var_types Compiler::getArgTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
             howToPassStruct = SPK_ByValue;
             useType         = TYP_STRUCT;
 
-#elif defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
+#elif defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64) || defined(TARGET_S390X)
 
             // Otherwise we pass this struct by reference to a copy
             // setup wbPassType and useType indicate that this is passed using one register (by reference to a copy)

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -396,7 +396,12 @@ unsigned Compiler::eeGetArgSize(CorInfoType corInfoType, CORINFO_CLASS_HANDLE ty
         // For each target that supports passing struct args in multiple registers
         // apply the target specific rules for them here:
 
-#if FEATURE_MULTIREG_ARGS
+#if defined(TARGET_S390X)
+        if (structSize > MAX_PASS_SINGLEREG_BYTES)
+        {
+            return TARGET_POINTER_SIZE;
+        }
+#elif FEATURE_MULTIREG_ARGS
 #if defined(TARGET_ARM64)
         // Any structs that are larger than MAX_PASS_MULTIREG_BYTES are always passed by reference
         if (structSize > MAX_PASS_MULTIREG_BYTES)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2274,14 +2274,18 @@ void emitter::emitGeneratePrologEpilog()
             case IGPT_FUNCLET_PROLOG:
                 INDEBUG(++funcletPrologCnt);
                 emitBegFuncletProlog(igPh);
+#if !defined(TARGET_S390X)
                 codeGen->genFuncletProlog(igPhBB);
+#endif
                 emitEndFuncletProlog();
                 break;
 
             case IGPT_FUNCLET_EPILOG:
                 INDEBUG(++funcletEpilogCnt);
                 emitBegFuncletEpilog(igPh);
+#if !defined(TARGET_S390X)
                 codeGen->genFuncletEpilog();
+#endif
                 emitEndFuncletEpilog();
                 break;
 
@@ -7707,9 +7711,8 @@ unsigned emitter::emitEndCodeGen(Compiler*         comp,
                     assert(!jmp->idAddr()->iiaHasInstrCount());
                     emitOutputLJ(NULL, adr, jmp);
 #elif defined(TARGET_S390X)
-                    //assert(!jmp->idAddr()->iiaHasInstrCount());
-                    //emitOutputLJ(NULL, adr, jmp);
-		    _ASSERTE(!"NYI"); 
+                    assert(!jmp->idAddr()->iiaHasInstrCount());
+                    emitOutputLJ(NULL, adr, jmp);
 #elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
                     // For LoongArch64 and RiscV64 `emitFwdJumps` is always false.
                     unreached();
@@ -7729,9 +7732,8 @@ unsigned emitter::emitEndCodeGen(Compiler*         comp,
                     // For LoongArch64 and RiscV64 `emitFwdJumps` is always false.
                     unreached();
 #elif defined(TARGET_S390X)
-		    _ASSERTE(!"NYI"); 
-                    //assert(!jmp->idAddr()->iiaHasInstrCount());
-                    //emitOutputLJ(NULL, adr, jmp);
+                    assert(!jmp->idAddr()->iiaHasInstrCount());
+                    emitOutputLJ(NULL, adr, jmp);
 #else
 #error Unsupported or unset target architecture
 #endif

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2275,6 +2275,7 @@ void emitter::emitGeneratePrologEpilog()
                 INDEBUG(++funcletPrologCnt);
                 emitBegFuncletProlog(igPh);
 #if !defined(TARGET_S390X)
+//TODO S390X: HAS TO BE IMPLEMENTED LATER.
                 codeGen->genFuncletProlog(igPhBB);
 #endif
                 emitEndFuncletProlog();
@@ -2283,6 +2284,7 @@ void emitter::emitGeneratePrologEpilog()
             case IGPT_FUNCLET_EPILOG:
                 INDEBUG(++funcletEpilogCnt);
                 emitBegFuncletEpilog(igPh);
+//TODO S390X: HAS TO BE IMPLEMENTED LATER
 #if !defined(TARGET_S390X)
                 codeGen->genFuncletEpilog();
 #endif

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1199,6 +1199,7 @@ protected:
                 case INS_nr:
                 case INS_or:
                 case INS_xr:
+                case INS_break:
                     size = 2;
                     break;
                 case INS_lgfi:

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -10165,7 +10165,19 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             assert((imm >= -524288) && (imm <= 524287));
             S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
             break;
-	    
+
+        case INS_stc:
+            op = emitInsCode(ins, fmt);
+            imm = emitGetInsSC(id);
+            S390_RX_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            break;
+
+        case INS_sth:
+            op = emitInsCode(ins, fmt);
+            imm = emitGetInsSC(id);
+            S390_RX_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            break;
+
         case INS_stmg:
             op = emitInsCode(ins, fmt);
             imm = emitGetInsSC(id);
@@ -10849,6 +10861,11 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             op = emitInsCode(ins, fmt);
             S390_RRE(dst, op, id->idReg1(), id->idReg2());
             break;
+
+        case INS_break:
+           op = emitInsCode(ins, fmt); //no-op
+           dst += emitOutputWord(dst, op);
+           break;
 
         default:
             _ASSERTE(!"NYI");

--- a/src/coreclr/jit/emits390x.cpp
+++ b/src/coreclr/jit/emits390x.cpp
@@ -10799,8 +10799,9 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_lgh:
         case INS_lgf:
             op = emitInsCode(ins, fmt);
-            S390_RRE(dst, op, id->idReg1(), id->idReg2());
-             break;
+            imm = emitGetInsSC(id);
+            S390_RXY_a(dst, op, id->idReg1(), 0, id->idReg2(), imm);
+            break;
         
         case INS_bras:
            op = emitInsCode(ins, fmt);
@@ -10845,6 +10846,11 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case INS_msr:
             op = emitInsCode(ins, fmt);
             S390_RRE(dst, op, id->idReg1(), id->idReg2());
+            break;
+
+        case INS_ar:
+            op = emitInsCode(ins, fmt);
+            S390_RR(dst, op, id->idReg1(), id->idReg2());
             break;
 
         case INS_agr:

--- a/src/coreclr/jit/targets390x.cpp
+++ b/src/coreclr/jit/targets390x.cpp
@@ -103,14 +103,14 @@ ABIPassingInformation S390xClassifier::Classify(Compiler*    comp,
     if (varTypeIsStruct(type))
     {
         unsigned size = structLayout->GetSize();
-        if (size > 16)
+        if (size > TARGET_POINTER_SIZE)
         {
             slots      = 1; // Passed by implicit byref
             passedSize = TARGET_POINTER_SIZE;
         }
         else
         {
-            slots      = (size + TARGET_POINTER_SIZE - 1) / TARGET_POINTER_SIZE;
+            slots = 1;
             passedSize = size;
         }
     }

--- a/src/coreclr/jit/targets390x.cpp
+++ b/src/coreclr/jit/targets390x.cpp
@@ -103,15 +103,12 @@ ABIPassingInformation S390xClassifier::Classify(Compiler*    comp,
     if (varTypeIsStruct(type))
     {
         unsigned size = structLayout->GetSize();
+        slots      = 1;
+        passedSize = size;
+//TODO -S390X : PASS BY VALUE FOR STRUCTS WITH SINGLE VECTOR MEMBER SHOULD BE HANDLED.
         if (size > TARGET_POINTER_SIZE)
         {
-            slots      = 1; // Passed by implicit byref
             passedSize = TARGET_POINTER_SIZE;
-        }
-        else
-        {
-            slots = 1;
-            passedSize = size;
         }
     }
     else

--- a/src/coreclr/jit/targets390x.h
+++ b/src/coreclr/jit/targets390x.h
@@ -28,10 +28,10 @@
   #define FEATURE_MULTIREG_RET          1  // Support for returning a single value in more than one register
   #define FEATURE_STRUCT_CLASSIFIER     0  // Uses a classifier function to determine is structs are passed/returned in more than one register
   #define MAX_PASS_SINGLEREG_BYTES      8  // Maximum size of a struct passed in a single register (16-byte vector).
-  #define MAX_PASS_MULTIREG_BYTES      16  // Maximum size of a struct that could be passed in more than one register (max is 4 16-byte vectors using an HVA)
-  #define MAX_RET_MULTIREG_BYTES       16  // Maximum size of a struct that could be returned in more than one register (Max is an HVA of 4 16-byte vectors)
-  #define MAX_ARG_REG_COUNT             2  // Maximum registers used to pass a single argument in multiple registers. (max is 4 128-bit vectors using an HVA)
-  #define MAX_RET_REG_COUNT             2  // Maximum registers used to return a value.
+  #define MAX_PASS_MULTIREG_BYTES       0  // Maximum size of a struct that could be passed in more than one register (max is 4 16-byte vectors using an HVA)
+  #define MAX_RET_MULTIREG_BYTES        0  // Maximum size of a struct that could be returned in more than one register (Max is an HVA of 4 16-byte vectors)
+  #define MAX_ARG_REG_COUNT             1  // Maximum registers used to pass a single argument in multiple registers. (max is 4 128-bit vectors using an HVA)
+  #define MAX_RET_REG_COUNT             1  // Maximum registers used to return a value.
 
   #define MAX_MULTIREG_COUNT            2  // Maximum number of registers defined by a single instruction (including calls).
                                            // This is also the maximum number of registers for a MultiReg node.

--- a/src/s390tests/tests/call_arg_struct_1.cs
+++ b/src/s390tests/tests/call_arg_struct_1.cs
@@ -1,0 +1,31 @@
+using System.Runtime.CompilerServices;
+
+struct FourDoubles
+{
+    public double A;
+    public double B;
+    public double C;
+    public double D;
+}
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static double addStruct(FourDoubles x)
+        => x.A + x.B + x.C + x.D;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static double s390xHw()
+    {
+        FourDoubles values = new FourDoubles();
+        values.A = 1.0;
+        values.B = 2.0;
+        values.C = 3.0;
+        values.D = 4.0;
+
+        return addStruct(values);
+    }
+
+    static int Main() => s390xHw() == 10.0 ? 0 : 1;
+}
+

--- a/src/s390tests/tests/call_args_struct_2.cs
+++ b/src/s390tests/tests/call_args_struct_2.cs
@@ -1,0 +1,38 @@
+using System.Runtime.CompilerServices;
+
+struct FourDoubles
+{
+    public double A;
+    public double B;
+    public double C;
+    public double D;
+}
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static FourDoubles passStructs(FourDoubles x, FourDoubles y) => x;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static double s390xHw()
+    {
+        FourDoubles first = new FourDoubles();
+        first.A = 1.0;
+        first.B = 2.0;
+        first.C = 3.0;
+        first.D = 4.0;
+
+        FourDoubles second = new FourDoubles();
+        second.A = 5.0;
+        second.B = 6.0;
+        second.C = 7.0;
+        second.D = 8.0;
+
+        FourDoubles result = passStructs(first, second);
+
+        return result.A + result.B + result.C + result.D;
+    }
+
+    static int Main() => s390xHw() == 10.0 ? 0 : 1;
+}
+

--- a/src/s390tests/tests/call_args_struct_3.cs
+++ b/src/s390tests/tests/call_args_struct_3.cs
@@ -1,0 +1,54 @@
+using System.Runtime.CompilerServices;
+
+struct FourDoubles
+{
+    public double A;
+    public double B;
+    public double C;
+    public double D;
+}
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static FourDoubles passStructs(
+        FourDoubles a,
+        FourDoubles b,
+        FourDoubles c,
+        FourDoubles d) => a;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static double s390xHw()
+    {
+        FourDoubles first = new FourDoubles();
+        first.A = 1.0;
+        first.B = 2.0;
+        first.C = 3.0;
+        first.D = 4.0;
+
+        FourDoubles second = new FourDoubles();
+        second.A = 5.0;
+        second.B = 6.0;
+        second.C = 7.0;
+        second.D = 8.0;
+
+        FourDoubles third = new FourDoubles();
+        third.A = 9.0;
+        third.B = 10.0;
+        third.C = 11.0;
+        third.D = 12.0;
+
+        FourDoubles fourth = new FourDoubles();
+        fourth.A = 13.0;
+        fourth.B = 14.0;
+        fourth.C = 15.0;
+        fourth.D = 16.0;
+
+        FourDoubles result = passStructs(first, second, third, fourth);
+
+        return result.A + result.B + result.C + result.D;
+    }
+
+    static int Main() => s390xHw() == 10.0 ? 0 : 1;
+}
+


### PR DESCRIPTION
-Removed multiple register argument path, and facilitated structs pass by reference.
- commented out genFuncletProlog, genCallFinally, genFuncletEpilog temporarily.
- Validate method cannot be Jitted completely now since 2  threads are deadlocked on a managed lock(EventListener.EventListenersLock). [since (genCallFinally/genFuncletProlog/genFuncletEpilog) is unimplemented.]