### PR TITLE
Fix genCall for helper indirection , Jitted Add functions.

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4638,6 +4638,9 @@ void CodeGen::genReportGenericContextArg(regNumber initReg, bool* pInitRegZeroed
 #elif defined(TARGET_RISCV64)
     genInstrWithConstant(ins_Store(TYP_I_IMPL), EA_PTRSIZE, reg, genFramePointerReg(),
                          compiler->lvaCachedGenericContextArgOffset(), rsGetRsvdReg());
+#elif defined(TARGET_S390X)
+    genInstrWithConstant(ins_Store(TYP_I_IMPL), EA_PTRSIZE, reg, genFramePointerReg(),
+                         compiler->lvaCachedGenericContextArgOffset(), REG_R1);
 #else  // !ARM64 !ARM !LOONGARCH64 !RISCV64
     // mov [ebp-lvaCachedGenericContextArgOffset()], reg
     GetEmitter()->emitIns_AR_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, reg, genFramePointerReg(),

--- a/src/coreclr/jit/codegens390x.cpp
+++ b/src/coreclr/jit/codegens390x.cpp
@@ -2937,7 +2937,7 @@ void CodeGen::genCall(GenTreeCall* call)
 
     void*     callAddr = nullptr;
     regNumber callReg  = REG_NA;
-
+    void*     indirection = nullptr;
     switch (callType)
     {
         case CT_USER_FUNC:
@@ -2948,7 +2948,6 @@ void CodeGen::genCall(GenTreeCall* call)
 
         case CT_HELPER:
         {
-	    void* indirection = nullptr;
             CorInfoHelpFunc helpFunc = compiler->eeGetHelperNum(call->gtCallMethHnd);
 
             callAddr = compiler->compGetHelperFtn(helpFunc, (void**)&indirection);
@@ -3054,16 +3053,28 @@ void CodeGen::genCall(GenTreeCall* call)
         {
             retSize = emitTypeSize(call->TypeGet());
         }
-	emitter::EmitCallType emitType;
-	if (callType == CT_HELPER)
-        {
-            emitType = emitter::EC_FUNC_TOKEN;
-        }
-	else
-        {
-            emitType = emitter::EC_FUNC_TOKEN;
-        }
+        emitter::EmitCallType emitType;
+        regNumber indirReg = REG_NA;
 
+        if (callAddr == nullptr)
+        {
+           if (call->gtControlExpr != nullptr)
+           {
+                genConsumeReg(call->gtControlExpr);
+                indirReg = call->gtControlExpr->GetRegNum();
+           }
+           else
+           {
+                indirReg = REG_R1;
+                instGen_Set_Reg_To_Imm(EA_PTR_DSP_RELOC, indirReg, (ssize_t)indirection);
+                GetEmitter()->emitIns_R_R_I(INS_lg, EA_PTRSIZE, indirReg, indirReg, 0);
+            }
+            emitType = emitter::EC_INDIR_R;
+        }
+        else
+        {
+            emitType = emitter::EC_FUNC_TOKEN;
+        }
         // Emit the call with full GC tracking
         GetEmitter()->emitIns_Call(
             emitType,
@@ -3077,7 +3088,7 @@ void CodeGen::genCall(GenTreeCall* call)
             gcrefRegs,
             byrefRegs,
             DebugInfo(),
-            REG_R2,     // ireg (for indirect)
+            indirReg,     // ireg (for indirect)
             REG_NA,     // xreg (for scaled index)
             0,          // xmul (multiplier)
             0,          // disp (displacement)
@@ -5719,67 +5730,8 @@ bool CodeGen::genInstrWithConstant(instruction ins,
                                    regNumber   tmpReg,
                                    bool        inUnwindRegion /* = false */)
 {
-    _ASSERTE(!"NYI");
-#if 0
     bool     immFitsInIns = false;
     emitAttr size         = EA_SIZE(attr);
-
-    // reg1 is usually a dest register
-    // reg2 is always source register
-    assert(tmpReg != reg2); // regTmp can not match any source register
-
-    switch (ins)
-    {
-        case INS_add:
-        case INS_sub:
-            if (imm < 0)
-            {
-                imm = -imm;
-                ins = (ins == INS_add) ? INS_sub : INS_add;
-            }
-            immFitsInIns = emitter::emitIns_valid_imm_for_add(imm, size);
-            break;
-
-        case INS_strb:
-            assert(size == EA_1BYTE);
-            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_1BYTE);
-            break;
-
-        case INS_strh:
-            assert(size == EA_2BYTE);
-            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_2BYTE);
-            break;
-
-        case INS_str:
-            // reg1 is a source register for store instructions
-            assert(tmpReg != reg1); // regTmp can not match any source register
-            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, size);
-            break;
-
-        case INS_ldrb:
-        case INS_ldrsb:
-            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_1BYTE);
-            break;
-
-        case INS_ldrh:
-        case INS_ldrsh:
-            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_2BYTE);
-            break;
-
-        case INS_ldrsw:
-            assert(size == EA_4BYTE);
-            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_4BYTE);
-            break;
-
-        case INS_ldr:
-            assert((size == EA_4BYTE) || (size == EA_8BYTE) || (size == EA_16BYTE));
-            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, size);
-            break;
-
-        default:
-            assert(!"Unexpected instruction in genInstrWithConstant");
-            break;
-    }
 
     if (immFitsInIns)
     {
@@ -5796,25 +5748,25 @@ bool CodeGen::genInstrWithConstant(instruction ins,
         // first we load the immediate into tmpReg
         instGen_Set_Reg_To_Imm(EA_PTRSIZE, tmpReg, imm);
         regSet.verifyRegUsed(tmpReg);
-
+        GetEmitter()->emitIns_R_R(INS_agr, EA_PTRSIZE, tmpReg, reg2);
+//TODO - s390x : Wasnt sure about these unwinding code so I commented these out.
         // when we are in an unwind code region
 
         // first we load the immediate into tmpReg
-        instGen_Set_Reg_To_Imm(EA_PTRSIZE, tmpReg, imm);
-        regSet.verifyRegUsed(tmpReg);
+        //instGen_Set_Reg_To_Imm(EA_PTRSIZE, tmpReg, imm);
+        //regSet.verifyRegUsed(tmpReg);
 
         // when we are in an unwind code region
         // we record the extra instructions using unwindPadding()
-        if (inUnwindRegion)
-        {
-            compiler->unwindPadding();
-        }
+        //if (inUnwindRegion)
+        //{
+        //    compiler->unwindPadding();
+        //}
 
         // generate the instruction using a three register encoding with the immediate in tmpReg
-        GetEmitter()->emitIns_R_R_R(ins, attr, reg1, reg2, tmpReg);
+        GetEmitter()->emitIns_R_R_I(ins, attr, reg1, tmpReg, 0);
     }
     return immFitsInIns;
-#endif
 }
 
 //---------------------------------------------------------------------

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -6437,10 +6437,16 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
         }
         else
         {
+#if defined(TARGET_S390X)
+            lvaCachedGenericContextArgOffs = stkOffs;
+            lvaIncrementFrameSize(TARGET_POINTER_SIZE);
+            stkOffs += TARGET_POINTER_SIZE;
+#else
             // For CORINFO_CALLCONV_PARAMTYPE (if needed)
             lvaIncrementFrameSize(TARGET_POINTER_SIZE);
             stkOffs -= TARGET_POINTER_SIZE;
             lvaCachedGenericContextArgOffs = stkOffs;
+#endif
         }
     }
 #ifndef JIT32_GCENCODER
@@ -6460,10 +6466,16 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
 
         if (!canUseExistingSlot)
         {
+#if defined(TARGET_S390X)
+            lvaCachedGenericContextArgOffs = stkOffs;
+            lvaIncrementFrameSize(TARGET_POINTER_SIZE);
+            stkOffs += TARGET_POINTER_SIZE;
+#else
             // When "this" is also used as generic context arg.
             lvaIncrementFrameSize(TARGET_POINTER_SIZE);
             stkOffs -= TARGET_POINTER_SIZE;
             lvaCachedGenericContextArgOffs = stkOffs;
+#endif
         }
     }
 #endif

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -10636,6 +10636,7 @@ void* CEEJitInfo::getHelperFtn(CorInfoHelpFunc    ftnNum,         /* IN  */
                 CodeVersionManager* manager = helperMD->GetCodeVersionManager();
 
                 NativeCodeVersion activeCodeVersion;
+
                 {
                     // Get active code version under a lock
                     CodeVersionManager::LockHolder codeVersioningLockHolder;
@@ -11518,11 +11519,48 @@ void CEEJitInfo::recordRelocation(void * location,
             // location points to the 4-byte displacement field (bytes 2-5 of BRASL).
             // The CPU uses PC of the instruction (byte 0), which is 2 bytes before.
             INT64 instrAddr = (INT64)location - 2;
-            delta = (INT64)target - instrAddr;
+            PCODE branchTarget = (PCODE)target;
+            delta = (INT64)branchTarget - (INT64)instrAddr;
             // s390x branch targets are always halfword-aligned
             _ASSERTE((delta & 1) == 0);
             delta = delta / 2;
-            _ASSERTE(delta >= (INT64)INT32_MIN && delta <= (INT64)INT32_MAX);
+            if (delta < (INT64)INT32_MIN || delta > (INT64)INT32_MAX)
+            {
+                TADDR baseAddr = instrAddr;
+                TADDR loAddr   = baseAddr - 0x100000000;   // -2^32
+                TADDR hiAddr   = baseAddr + 0xFFFFFFFE;    // +2^32-2
+
+                if (loAddr > baseAddr)
+                    loAddr = UINT64_MIN;
+                if (hiAddr < baseAddr)
+                    hiAddr = UINT64_MAX;
+
+                PCODE jumpStubAddr = ExecutionManager::jumpStub(m_pMethodBeingCompiled,
+                                                                branchTarget,
+                                                                (BYTE *) loAddr,
+                                                                (BYTE *) hiAddr,
+                                                                NULL,
+                                                                false);
+
+                m_reserveForJumpStubs = max((size_t)0x400, m_reserveForJumpStubs + 2*BACK_TO_BACK_JUMP_ALLOCATE_SIZE);
+
+                if (jumpStubAddr == 0)
+                {
+                    m_fJumpStubOverflow = TRUE;
+                    break;
+                }
+
+                delta = (INT64)jumpStubAddr - (INT64)instrAddr;
+                _ASSERTE((delta & 1) == 0);
+                delta = delta / 2;
+
+                if (delta < (INT64)INT32_MIN || delta > (INT64)INT32_MAX)
+                {
+                    _ASSERTE(!"jump stub was not in expected range");
+                    EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
+                }
+            }
+
             *((INT32*)locationRW) = (INT32)delta;
         }
         break;

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -722,7 +722,7 @@ public:
     }
 #endif
 
-#if defined(TARGET_AMD64) || defined(TARGET_ARM64)
+#if defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_S390X)
     void SetJumpStubOverflow(BOOL fJumpStubOverflow)
     {
         LIMITED_METHOD_CONTRACT;
@@ -764,7 +764,7 @@ public:
         LIMITED_METHOD_CONTRACT;
         return 0;
     }
-#endif // defined(TARGET_AMD64) || defined(TARGET_ARM64)
+#endif // defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_S390X)
 
 #ifdef FEATURE_ON_STACK_REPLACEMENT
     // Called by the runtime to supply patchpoint information to the jit.
@@ -798,7 +798,7 @@ public:
 #ifdef TARGET_AMD64
           m_fAllowRel32(FALSE),
 #endif
-#if defined(TARGET_AMD64) || defined(TARGET_ARM64)
+#if defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_S390X)
           m_fJumpStubOverflow(FALSE),
           m_reserveForJumpStubs(0),
 #endif

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1084,7 +1084,7 @@ public:
     bool IsVersionable()
     {
         WRAPPER_NO_CONTRACT;
-        return false; // FIXME-S390 IsEligibleForTieredCompilation() || IsEligibleForReJIT();
+        return IsEligibleForTieredCompilation() || IsEligibleForReJIT();
     }
 
     // True iff all calls to the method should funnel through a Precode which can be updated to point to the current method

--- a/src/coreclr/vm/s390x/jithelpers.S
+++ b/src/coreclr/vm/s390x/jithelpers.S
@@ -72,6 +72,6 @@ LEAF_END_MARKED JIT_ByRefWriteBarrier, _TEXT
 // __declspec(naked) void F_CALL_CONV JIT_WriteBarrier_Callable(Object **dst, Object* val)
 .balign 16
 LEAF_ENTRY  JIT_WriteBarrier_Callable, _TEXT
-// NOT YET IMPLEMENTED
-.long 0x34
+stg     %r3, 0(%r2)
+br      %r14
 LEAF_END JIT_WriteBarrier_Callable, _TEXT


### PR DESCRIPTION
- Fix slot allocation in frame layout - add upward going stack offsets.
- Fix genCall for helper call indirections, and add out of range direct calls. 
- Handle BRASL displacement overflow via jump stub - When the displacement overflows, allocate a stub  within the ±2 GB window and redirect BRASL to it. 
-  WriteBarrierCallable change is temporary and needs to be fixed.