### PR TITLE
Fix small struct spill frame layout overlap on s390x

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -6126,8 +6126,9 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
     // (1) Account for things that are set up by the prolog and undone by the epilog.
     //
 #if defined TARGET_S390X
-    int stkOffs              = 160;
-    int originalFrameSize    = 160;
+    int outArgSize           = (int)(unsigned)lvaOutgoingArgSpaceSize;
+    int stkOffs              = 160 + outArgSize;
+    int originalFrameSize    = 160 + outArgSize;
 #else
     int stkOffs              = 0;
     int originalFrameSize    = 0;
@@ -6240,6 +6241,11 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
 
     assert(compCalleeRegsPushed >= 2); // always FP/RA.
     stkOffs -= (compCalleeRegsPushed << 3);
+
+#elif defined(TARGET_S390X)
+    // Callee-saved registers are stored in the caller's 160-byte register
+    // save area (via stmg), not pushed onto the callee's frame.
+    // No stkOffs adjustment needed here.
 
 #else // !TARGET_LOONGARCH64 && !TARGET_RISCV64
 #ifdef TARGET_ARM
@@ -6943,7 +6949,12 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
 
     // compLclFrameSize equals our negated virtual stack offset minus the pushed registers and return address
     // and the pushed frame pointer register which for some strange reason isn't part of 'compCalleeRegsPushed'.
+
+#if defined(TARGET_S390X)
+    int pushedCount = 0;
+#else
     int pushedCount = compCalleeRegsPushed;
+#endif
 
 #ifdef TARGET_ARM64
     if (info.compIsVarArgs)

--- a/src/s390tests/tests/call_args_struct_small_spill.cs
+++ b/src/s390tests/tests/call_args_struct_small_spill.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Runtime.CompilerServices;
+
+// Tests that small structs (<= 8 bytes, passed by value in register on s390x)
+// are correctly spilled to the stack when they overflow the available argument
+// registers (r2-r6), and that spilled struct args do not clobber caller locals.
+
+struct Small
+{
+    public int X;
+    public int Y;
+}
+
+struct Tiny
+{
+    public int V;
+}
+
+class Program
+{
+    // Test 1: 6 small structs -- the 6th must spill to the stack.
+    // The caller has a local variable 'a' whose frame slot must not overlap
+    // with the outgoing argument area.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Sum6(Small s1, Small s2, Small s3, Small s4, Small s5, Small s6)
+        => s1.X + s1.Y + s2.X + s2.Y + s3.X + s3.Y
+         + s4.X + s4.Y + s5.X + s5.Y + s6.X + s6.Y;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int TestSmallStructSpill6()
+    {
+        int a = 42;
+        Small p1 = new Small { X = 1, Y = 10 };
+        Small p2 = new Small { X = 2, Y = 20 };
+        Small p3 = new Small { X = 3, Y = 30 };
+        Small p4 = new Small { X = 4, Y = 40 };
+        Small p5 = new Small { X = 5, Y = 50 };
+        Small p6 = new Small { X = 6, Y = 60 };
+
+        int result = Sum6(p1, p2, p3, p4, p5, p6);
+
+        // 'a' must still be 42 after the call -- if the 6th arg's spill slot
+        // overlaps with 'a', this check will fail.
+        if (a != 42)
+        {
+            Console.WriteLine($"FAIL TestSmallStructSpill6: local a clobbered, got {a}");
+            return 1;
+        }
+        if (result != 231)
+        {
+            Console.WriteLine($"FAIL TestSmallStructSpill6: expected 231, got {result}");
+            return 1;
+        }
+        return 0;
+    }
+
+    // Test 2: 7 small structs -- the 6th and 7th must spill.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Sum7(Small s1, Small s2, Small s3, Small s4, Small s5,
+                    Small s6, Small s7)
+        => s1.X + s1.Y + s2.X + s2.Y + s3.X + s3.Y
+         + s4.X + s4.Y + s5.X + s5.Y + s6.X + s6.Y
+         + s7.X + s7.Y;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int TestSmallStructSpill7()
+    {
+        int a = 99;
+        int b = 77;
+        Small p1 = new Small { X = 1, Y = 10 };
+        Small p2 = new Small { X = 2, Y = 20 };
+        Small p3 = new Small { X = 3, Y = 30 };
+        Small p4 = new Small { X = 4, Y = 40 };
+        Small p5 = new Small { X = 5, Y = 50 };
+        Small p6 = new Small { X = 6, Y = 60 };
+        Small p7 = new Small { X = 7, Y = 70 };
+
+        int result = Sum7(p1, p2, p3, p4, p5, p6, p7);
+
+        if (a != 99 || b != 77)
+        {
+            Console.WriteLine($"FAIL TestSmallStructSpill7: locals clobbered, a={a} b={b}");
+            return 1;
+        }
+        // expected: (1+10)+(2+20)+(3+30)+(4+40)+(5+50)+(6+60)+(7+70) = 308
+        if (result != 308)
+        {
+            Console.WriteLine($"FAIL TestSmallStructSpill7: expected 308, got {result}");
+            return 1;
+        }
+        return 0;
+    }
+
+    // Test 3: Mixed int args + small struct spill.
+    // 5 int args in r2-r6, then a small struct must spill.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int MixedSum(int a, int b, int c, int d, int e, Small s)
+        => a + b + c + d + e + s.X + s.Y;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int TestMixedIntAndStructSpill()
+    {
+        int local = 123;
+        Small s = new Small { X = 100, Y = 200 };
+        int result = MixedSum(1, 2, 3, 4, 5, s);
+
+        if (local != 123)
+        {
+            Console.WriteLine($"FAIL TestMixedIntAndStructSpill: local clobbered, got {local}");
+            return 1;
+        }
+        if (result != 315)
+        {
+            Console.WriteLine($"FAIL TestMixedIntAndStructSpill: expected 315, got {result}");
+            return 1;
+        }
+        return 0;
+    }
+
+    // Test 4: 4-byte struct (Tiny) as spilled arg.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int TinySum(int a, int b, int c, int d, int e, Tiny t)
+        => a + b + c + d + e + t.V;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int TestTinyStructSpill()
+    {
+        int local = 555;
+        Tiny t = new Tiny { V = 50 };
+        int result = TinySum(10, 20, 30, 40, 50, t);
+
+        if (local != 555)
+        {
+            Console.WriteLine($"FAIL TestTinyStructSpill: local clobbered, got {local}");
+            return 1;
+        }
+        if (result != 200)
+        {
+            Console.WriteLine($"FAIL TestTinyStructSpill: expected 200, got {result}");
+            return 1;
+        }
+        return 0;
+    }
+
+    // Test 5: Return value from callee is correct even with struct spill.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Small ReturnSmall(int a, int b, int c, int d, int e, Small s)
+        => new Small { X = s.X + a, Y = s.Y + e };
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int TestReturnSmallStruct()
+    {
+        Small s = new Small { X = 10, Y = 20 };
+        Small result = ReturnSmall(1, 2, 3, 4, 5, s);
+
+        if (result.X != 11 || result.Y != 25)
+        {
+            Console.WriteLine($"FAIL TestReturnSmallStruct: expected (11,25), got ({result.X},{result.Y})");
+            return 1;
+        }
+        return 0;
+    }
+
+    static int Main()
+    {
+        int failures = 0;
+
+        failures += TestSmallStructSpill6();
+        failures += TestSmallStructSpill7();
+        failures += TestMixedIntAndStructSpill();
+        failures += TestTinyStructSpill();
+        failures += TestReturnSmallStruct();
+
+        if (failures == 0)
+            Console.WriteLine("ALL PASS");
+        else
+            Console.WriteLine($"FAILURES: {failures}");
+
+        return failures;
+    }
+}
+


### PR DESCRIPTION
On s390x, when a small struct (<=8 bytes) overflows the argument registers (r2-r6) and spills to the outgoing parameter area at SP+160, local variables were incorrectly allocated starting atSP+160 too, causing the spilled argument to clobber locals.
- Start local variable offsets at 160 + lvaOutgoingArgSpaceSize to place locals after the outgoing parameter area
- Skip compCalleeRegsPushed subtraction since s390x saves callee registers into the caller's 160-byte save area via stmg not by pushing onto the callee's frame
- Set pushedCount=0 for the frame size assertion to match